### PR TITLE
Expose add_apt_key rule's impl, attrs and outputs.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -23,7 +23,7 @@ workspace(name = "base_images_docker")
 # Docker rules.
 git_repository(
     name = "io_bazel_rules_docker",
-    commit = "452878d665648ada0aaf816931611fdd9c683a97",
+    commit = "1144f83122750fe4aca139bd0f205d99c9bd94c1",
     remote = "https://github.com/bazelbuild/rules_docker.git",
 )
 

--- a/package_managers/apt_key.bzl
+++ b/package_managers/apt_key.bzl
@@ -14,46 +14,124 @@
 
 """Rule for configuring apt GPG keys"""
 
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
-load("//util:run.bzl", "container_run_and_extract")
+load("@io_bazel_rules_docker//container:container.bzl", _container = "container")
+load("@base_images_docker//util:run.bzl", _extract = "extract")
 
-def add_apt_key(name, keys, image, gpg_image=None):
+def _impl(ctx, name=None, keys=None, image_tar=None, gpg_image=None, output_executable=None, output_tarball=None, output_layer=None):
+    """Implementation for the add_apt_key rule.
+
+    Args:
+        ctx: The bazel rule context
+        name: str, overrides ctx.label.name
+        keys: File list, overrides ctx.files.keys
+        image_tar: File, overrides ctx.file.image
+        gpg_image: File, overrides ctx.file.gpg_image
+        output_executable: File to use as output for script to load docker image,
+            overrides ctx.outputs.executable
+        output_tarball: File, overrides ctx.outputs.out
+        output_layer: File, overrides ctx.outputs.layer
+    """
+    name = name or ctx.label.name
+    keys = keys or ctx.files.keys
+    image_tar = image_tar or ctx.file.image_tar
+    gpg_image = gpg_image or ctx.file.gpg_image
+    output_executable = output_executable or ctx.outputs.executable
+    output_tarball = output_tarball or ctx.outputs.out
+    output_layer = output_layer or ctx.outputs.layer
+
     # First build an image capable of adding an apt-key.
     # This requires the keyfile and the "gnupg package."
 
     # If the user specified an alternate base for this, use it.
     # Otherwise use the same base image we want the key in.
-
     if gpg_image == None:
-        gpg_image = image
+        gpg_image = image_tar
 
     key_image = "%s.key" % name
-    docker_build(
+    key_image_output_executable = ctx.actions.declare_file("%s" % key_image)
+    key_image_output_tarball = ctx.actions.declare_file("%s.tar" % key_image)
+    key_image_output_layer = ctx.actions.declare_file("%s-layer.tar" % key_image)
+
+    key_image_result = _container.image.implementation(
+        ctx,
         name=key_image,
         base=gpg_image,
         directory="/gpg",
         files=keys,
+        output_executable=key_image_output_executable,
+        output_tarball=key_image_output_tarball,
+        output_layer=key_image_output_layer
     )
 
     commands = [
         "apt-get update",
         "apt-get install -y -q gnupg",
-        # In a macro we don't get to see exactly what the key file will be named,
-        # so we put it in a special directory and use glob.
+        # Put keys in a special directory and use glob.
         "for file in /gpg/*; do apt-key add \$file; done"
     ]
+    extract_file_name = "/etc/apt/trusted.gpg"
+    extract_file_out = ctx.actions.declare_file(name + "-trusted.gpg")
 
-    gpg_name="%s_gpg" % name
-    container_run_and_extract(
-        name=gpg_name,
-        image=key_image,
-        commands=commands,
-        extract_file="/etc/apt/trusted.gpg"
+    # container_image rules always generate an image named 'bazel/$package:$name'.
+    image_name = "bazel/%s:%s" % (key_image_output_tarball.owner.package,
+                                  key_image_output_tarball.basename.split(".tar")[0])
+
+    _extract.implementation(
+        ctx,
+        name = name,
+        image_tar = key_image_output_tarball,
+        image_name = image_name,
+        commands = commands,
+        extract_file = extract_file_name,
+        output_file = extract_file_out,
     )
 
-    docker_build(
+    # Build the final image with additional gpg keys in it.
+
+    result = _container.image.implementation(
+        ctx,
         name=name,
-        base=image,
-        directory="/etc/apt/",
-        files=[gpg_name],
+        base=image_tar,
+        directory="/etc/apt/trusted.gpg.d/",
+        files=[extract_file_out],
+        output_executable=output_executable,
+        output_tarball=output_tarball,
+        output_layer=output_layer
     )
+
+    return struct(runfiles = result.runfiles,
+                  files = result.files,
+                  container_parts = result.container_parts)
+
+
+_attrs = _container.image.attrs + _extract.attrs + {
+    "keys": attr.label_list(
+        allow_files = True,
+        mandatory = True,
+    ),
+    "gpg_image": attr.label(
+        allow_files = True,
+        single_file = True,
+    ),
+    # Redeclare following attributes of _extract to be non-mandatory.
+    "image_name": attr.string(doc = "name of image to run commands on"),
+    "commands": attr.string_list(doc = "commands to run"),
+    "extract_file": attr.string(doc = "path to file to extract from container"),
+    "output_file": attr.string()
+}
+
+_outputs = _container.image.outputs
+
+# Export add_apt_key rule for other bazel rules to depend on.
+key = struct(
+    attrs = _attrs,
+    outputs = _outputs,
+    implementation = _impl,
+)
+
+add_apt_key = rule(
+    attrs = _attrs,
+    outputs = _outputs,
+    implementation = _impl,
+    executable = True,
+)

--- a/package_managers/download_pkgs.bzl
+++ b/package_managers/download_pkgs.bzl
@@ -74,7 +74,7 @@ def _impl(ctx, image_tar=None, packages=None, additional_repos=None, output_exec
 
     # docker_build rules always generate an image named 'bazel/$package:$name'.
     builder_image_name = "bazel/%s:%s" % (image_tar.owner.package,
-                                          image_tar.owner.name.split(".tar")[0])
+                                          image_tar.basename.split(".tar")[0])
 
     # Generate a shell script to run apt_get inside this docker image.
     # TODO(tejaldesai): Replace this by docker_run rule

--- a/package_managers/install_pkgs.bzl
+++ b/package_managers/install_pkgs.bzl
@@ -84,7 +84,7 @@ def _impl(ctx, image_tar=None, installables_tar=None, installation_cleanup_comma
   )
 
   builder_image_name = "bazel/%s:%s" % (image_tar.owner.package,
-                                        image_tar.owner.name.split(".tar")[0])
+                                        image_tar.basename.split(".tar")[0])
   unstripped_tar = ctx.actions.declare_file(output_tar.basename + ".unstripped")
 
   build_contents = """\

--- a/tests/package_managers/BUILD
+++ b/tests/package_managers/BUILD
@@ -48,7 +48,7 @@ sh_test(
 
 add_apt_key(
     name = "ubuntu_gpg_image",
-    image = "//ubuntu:ubuntu_16_0_4_vanilla.tar",
+    image_tar = "//ubuntu:ubuntu_16_0_4_vanilla.tar",
     keys = [
         "@bazel_gpg//file",
     ],
@@ -88,7 +88,7 @@ rule_test(
 
 add_apt_key(
     name = "gpg_image",
-    image = "//debian/reproducible:debian9",
+    image_tar = "//debian/reproducible:debian9.tar",
     keys = [
         "@bazel_gpg//file",
         "@launchpad_openjdk_gpg//file",


### PR DESCRIPTION
Similar idea as previous PRs to refactor install_pkgs (#194), and download_pkgs (#196).