### PR TITLE
Strip away 'Hostname' from 'config' as well.

### DIFF
--- a/util/config_stripper.py
+++ b/util/config_stripper.py
@@ -150,6 +150,9 @@ def strip_config(path, new_diff_ids):
     # Base container info is not required and changes every build, so delete it.
     if 'container' in config:
       del config['container']
+    if ('config' in config and
+        'Hostname' in config['config']):
+      del config['config']['Hostname']
     if ('container_config' in config and
         'Hostname' in config['container_config']):
       del config['container_config']['Hostname']


### PR DESCRIPTION
Previously, it was only removed from 'container_config'. But it is
observed to appear in the 'config' sometimes as well.