### PR TITLE
Remove 'bazel/$package:$tag' naming format requirements from add_apt_key, install_pkgs, and download_pkgs rules

### DIFF
--- a/package_managers/apt_key.bzl
+++ b/package_managers/apt_key.bzl
@@ -33,7 +33,7 @@ def _impl(ctx, name=None, keys=None, image_tar=None, gpg_image=None, output_exec
     """
     name = name or ctx.label.name
     keys = keys or ctx.files.keys
-    image_tar = image_tar or ctx.file.image_tar
+    image_tar = image_tar or ctx.file.image
     gpg_image = gpg_image or ctx.file.gpg_image
     output_executable = output_executable or ctx.outputs.executable
     output_tarball = output_tarball or ctx.outputs.out
@@ -72,15 +72,10 @@ def _impl(ctx, name=None, keys=None, image_tar=None, gpg_image=None, output_exec
     extract_file_name = "/etc/apt/trusted.gpg"
     extract_file_out = ctx.actions.declare_file(name + "-trusted.gpg")
 
-    # container_image rules always generate an image named 'bazel/$package:$name'.
-    image_name = "bazel/%s:%s" % (key_image_output_tarball.owner.package,
-                                  key_image_output_tarball.basename.split(".tar")[0])
-
     _extract.implementation(
         ctx,
         name = name,
-        image_tar = key_image_output_tarball,
-        image_name = image_name,
+        image = key_image_output_tarball,
         commands = commands,
         extract_file = extract_file_name,
         output_file = extract_file_out,
@@ -114,7 +109,6 @@ _attrs = _container.image.attrs + _extract.attrs + {
         single_file = True,
     ),
     # Redeclare following attributes of _extract to be non-mandatory.
-    "image_name": attr.string(doc = "name of image to run commands on"),
     "commands": attr.string_list(doc = "commands to run"),
     "extract_file": attr.string(doc = "path to file to extract from container"),
     "output_file": attr.string()

--- a/tests/package_managers/BUILD
+++ b/tests/package_managers/BUILD
@@ -31,7 +31,7 @@ rule_test(
 file_test(
     name = "test_download_pkgs_docker_run",
     file = ":test_download_pkgs",
-    regexp = ".*docker run -w=\"/\" -d --privileged bazel/ubuntu:ubuntu_16_0_4_vanilla sh -c $'.*",
+    regexp = ".*ubuntu/ubuntu_16_0_4_vanilla.tar).*",
 )
 
 file_test(
@@ -48,7 +48,7 @@ sh_test(
 
 add_apt_key(
     name = "ubuntu_gpg_image",
-    image_tar = "//ubuntu:ubuntu_16_0_4_vanilla.tar",
+    image = "//ubuntu:ubuntu_16_0_4_vanilla.tar",
     keys = [
         "@bazel_gpg//file",
     ],
@@ -88,7 +88,7 @@ rule_test(
 
 add_apt_key(
     name = "gpg_image",
-    image_tar = "//debian/reproducible:debian9.tar",
+    image = "//debian/reproducible:debian9.tar",
     keys = [
         "@bazel_gpg//file",
         "@launchpad_openjdk_gpg//file",

--- a/tests/package_managers/BUILD
+++ b/tests/package_managers/BUILD
@@ -31,7 +31,7 @@ rule_test(
 file_test(
     name = "test_download_pkgs_docker_run",
     file = ":test_download_pkgs",
-    regexp = ".* ubuntu/ubuntu_16_0_4_vanilla.tar)$",
+    regexp = "image_name=.* ubuntu/ubuntu_16_0_4_vanilla.tar)$",
 )
 
 file_test(

--- a/tests/package_managers/BUILD
+++ b/tests/package_managers/BUILD
@@ -31,7 +31,7 @@ rule_test(
 file_test(
     name = "test_download_pkgs_docker_run",
     file = ":test_download_pkgs",
-    regexp = ".*ubuntu/ubuntu_16_0_4_vanilla.tar).*",
+    regexp = ".* ubuntu/ubuntu_16_0_4_vanilla.tar)$",
 )
 
 file_test(

--- a/tests/util/BUILD
+++ b/tests/util/BUILD
@@ -83,6 +83,6 @@ container_test(
 sh_test(
     name = "image_loader_test",
     srcs = ["image_loader_test.sh"],
+    args = ["$(location //util:image_loader.sh)"],
     data = ["//util:image_loader.sh"],
-    args = ["$(location //util:image_loader.sh)"]
 )

--- a/tests/util/BUILD
+++ b/tests/util/BUILD
@@ -79,3 +79,10 @@ container_test(
     configs = [":container_commit.yaml"],
     image = ":test_container_commit_image",
 )
+
+sh_test(
+    name = "image_loader_test",
+    srcs = ["image_loader_test.sh"],
+    data = ["//util:image_loader.sh"],
+    args = ["$(location //util:image_loader.sh)"]
+)

--- a/tests/util/image_loader_test.sh
+++ b/tests/util/image_loader_test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+image_loader=$1
+
+set -exu
+
+test `./$image_loader -o 'Loaded image ID: sha256:593fa78799748eecb65019e8cc54b1f8dfa29fb4fe3b28bc597e3972a7b15ce3'` = "593fa78799748eecb65019e8cc54b1f8dfa29fb4fe3b28bc597e3972a7b15ce3"
+
+test `./$image_loader -o 'Loaded image: ubuntu:latest'` = "ubuntu:latest"
+
+exit 0

--- a/util/BUILD
+++ b/util/BUILD
@@ -9,4 +9,5 @@ exports_files([
     "commit.sh.tpl",
     "extract.sh.tpl",
     "image_util.sh",
+    "image_loader.sh",
 ])

--- a/util/commit.sh.tpl
+++ b/util/commit.sh.tpl
@@ -5,11 +5,12 @@ set -ex
 # Load utils
 source %{util_script}
 
-%{load_statement}
+# Load the image and remember its name
+image_name=$(sh %{image_loader_path} %{image_tar})
 
-id=$(docker run -d %{image} %{commands})
+id=$(docker run -d $image_name %{commands})
 
-reset_cmd %{image} $id %{output_image}
+reset_cmd $image_name $id %{output_image}
 
 docker save %{output_image} -o %{output_tar}
 docker rm $id

--- a/util/extract.sh.tpl
+++ b/util/extract.sh.tpl
@@ -2,9 +2,10 @@
 
 set -ex
 
-%{load_statement}
+# Load the image and remember its name
+image_name=$(sh %{image_loader_path} %{image_tar})
 
-id=$(docker run -d %{image} %{commands})
+id=$(docker run -d $image_name %{commands})
 
 docker wait $id
 docker cp $id:%{extract_file} %{output}

--- a/util/image_loader.sh
+++ b/util/image_loader.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
-temp=$(docker load --input $1)
+#For overriding loading and using a default value instead
+if [ $1 = "-o" ]
+then
+  temp=$2
+else
+  temp=$(docker load --input $1)
+fi
+
 if [ `echo $temp | cut -d " " -f3` = "ID:" ]
 then # The command outputed the image ID message, so we extract the image ID
   image_name=$(echo $temp | cut -d ":" -f3)

--- a/util/image_loader.sh
+++ b/util/image_loader.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+temp=$(docker load --input $1)
+if [ `echo $temp | cut -d " " -f3` = "ID:" ]
+then # The command outputed the image ID message, so we extract the image ID
+  image_name=$(echo $temp | cut -d ":" -f3)
+else # The command outputed the image tag message, so we extract the image tag
+  image_name=$(echo $temp | cut -d " " -f3)
+fi
+echo $image_name

--- a/util/run.bzl
+++ b/util/run.bzl
@@ -23,63 +23,57 @@ load(
     "container_bundle",
 )
 
-def _extract_impl(ctx, name="", image_tar=None, image_name="", commands=None, extract_file="", output_file=None):
-    """Implementation for the _run_and_extract rule.
+def _extract_impl(ctx, name = "", image = None, commands = None, extract_file = "", output_file = ""):
+    """Implementation for the container_run_and_extract rule.
+
+    This rule runs a set of commands in a given image, waits for the commands
+    to finish, and then extracts a given file from the container to the
+    bazel-out directory.
 
     Args:
         ctx: The bazel rule context
         name: String, overrides ctx.label.name
-        image_tar: File, overrides ctx.file.image_tar
-        image_name: String, overrides ctx.attr.image_name
+        image: File, overrides ctx.file.image_tar
         commands: String list, overrides ctx.attr.commands
-        extract_file: String, overrides ctx.attr.extract_file
-        output_file: File, overrides ctx.outputs.out
+        extract_file: File, overrides ctx.outputs.out
     """
+
     name = name or ctx.label.name
-    image_tar = image_tar or ctx.file.image_tar
-    image_name = image_name or ctx.attr.image_name
+    image = image or ctx.file.image
     commands = commands or ctx.attr.commands
     extract_file = extract_file or ctx.attr.extract_file
     output_file = output_file or ctx.outputs.out
-
-    # Since we're always bundling/renaming the image in the macro, this is valid.
-    load_statement = 'docker load -i %s' % image_tar.path
-
     script = ctx.new_file(name + ".build")
 
     # Generate a shell script to execute the run statement
     ctx.actions.expand_template(
-        template=ctx.file._extract_tpl,
-        output=script,
-        substitutions={
-          "%{load_statement}": load_statement,
-          "%{image}": image_name,
-          "%{commands}": _process_commands(commands),
-          "%{extract_file}": extract_file,
-          "%{output}": output_file.path,
+        template = ctx.file._extract_tpl,
+        output = script,
+        substitutions = {
+            "%{image_tar}": image.path,
+            "%{commands}": _process_commands(commands),
+            "%{extract_file}": extract_file,
+            "%{output}": output_file.path,
+            "%{image_loader_path}": ctx.file._image_loader.path,
         },
         is_executable=True,
     )
 
     ctx.actions.run(
-        outputs=[output_file],
-        inputs=[image_tar],
-        executable=script,
+        outputs = [output_file],
+        inputs = [image, ctx.file._image_loader],
+        executable = script,
     )
 
     return struct()
 
 _extract_attrs = {
-    "image_tar": attr.label(
+    "image": attr.label(
         executable = True,
         allow_files = True,
         mandatory = True,
         single_file = True,
         cfg = "target",
-    ),
-    "image_name": attr.string(
-        doc = "name of image to run commands on",
-        mandatory = True,
     ),
     "commands": attr.string_list(
         doc = "commands to run",
@@ -95,70 +89,50 @@ _extract_attrs = {
         allow_files = True,
         single_file = True,
     ),
-    "output_file": attr.string(
-        mandatory = True,
+    "_image_loader": attr.label(
+      default = "//util:image_loader.sh",
+      allow_files = True,
+      single_file = True,
     ),
 }
 
 _extract_outputs = {
-    "out": "%{output_file}",
+    "out": "%{name}%{extract_file}",
 }
 
-# Export _run_and_extract rule for other bazel rules to depend on.
+# Export container_run_and_extract rule for other bazel rules to depend on.
 extract = struct(
     attrs = _extract_attrs,
     outputs = _extract_outputs,
     implementation = _extract_impl,
 )
 
-_run_and_extract = rule(
+
+'''
+This rule runs a set of commands in a given image, waits for the commands
+    to finish, and then extracts a given file from the container to the
+    bazel-out directory.
+
+    name: A unique name for this rule.
+    image: The image to run the commands in.
+    commands: A list of commands to run (sequentially) in the container.
+    extract_file: The file to extract from the container.
+'''
+container_run_and_extract = rule(
     attrs = _extract_attrs,
     outputs = _extract_outputs,
     implementation = _extract_impl,
 )
 
-def container_run_and_extract(name, image, commands, extract_file):
-    """Macro to wrap the run_and_extract implementation.
+def _commit_impl(ctx):
+    """Implementation for the container_run_and_commit rule.
 
     This rule runs a set of commands in a given image, waits for the commands
-    to finish, and then extracts a given file from the container to the
-    bazel-out directory.
+    to finish, and then commits the container to a new image.
 
     Args:
-        name: A unique name for this rule.
-        image: The image to run the commands in.
-        commands: A list of commands to run (sequentially) in the container.
-        extract_file: The file to extract from the container.
+        ctx: The bazel rule context
     """
-    image_tar, intermediate_image = _rename_image(image, name)
-
-    _run_and_extract(
-        name = name,
-        image_name = intermediate_image,
-        image_tar = image_tar + ".tar",
-        commands = commands,
-        extract_file = extract_file,
-        output_file = name + extract_file,
-    )
-
-"""Runs commands in a container and extracts a target file from the container.
-
-This rule runs a set of commands in a given image, waits for the commands
-to finish, and then extracts a given file from the container.
-
-Args:
-    image_name: Name of the image to run commands on
-    image_tar: Tarball of image to run commands on
-    commands: A list of commands to run (sequentially) in the container.
-    extract_file: The file to extract from the container.
-    output_file: Path to output file extracted from container.
-    _extract_tpl: Template for generated script to run docker commands.
-"""
-
-def _commit_impl(ctx):
-    # Since we're always bundling/renaming the image in the macro, this is valid.
-    load_statement = 'docker load -i %s' % ctx.file.image_tar.path
-
     script = ctx.new_file(ctx.label.name + ".build")
 
     # Generate a shell script to execute the run statement
@@ -169,17 +143,17 @@ def _commit_impl(ctx):
           "%{util_script}": ctx.file._image_utils.path,
           "%{output_image}": 'bazel/%s:%s' % (ctx.label.package or 'default',
                                               ctx.attr.name),
-          "%{load_statement}": load_statement,
-          "%{image}": ctx.attr.image_name,
+          "%{image_tar}": ctx.file.image.path,
           "%{commands}": _process_commands(ctx.attr.commands),
           "%{output_tar}": ctx.outputs.out.path,
+          "%{image_loader_path}": ctx.file._image_loader.path,
         },
         is_executable=True,
     )
 
-    runfiles = [ctx.file.image_tar, ctx.file._image_utils] + \
-                ctx.attr.image_tar.files.to_list() + \
-                ctx.attr.image_tar.data_runfiles.files.to_list()
+    runfiles = [ctx.file.image, ctx.file._image_utils, ctx.file._image_loader] + \
+                ctx.attr.image.files.to_list() + \
+                ctx.attr.image.data_runfiles.files.to_list()
 
     ctx.actions.run(
         outputs=[ctx.outputs.out],
@@ -189,17 +163,25 @@ def _commit_impl(ctx):
 
     return struct()
 
-_run_and_commit = rule(
+"""Runs commands in a container and commits the container to a new image.
+
+This rule runs a set of commands in a given image, waits for the commands
+to finish, and then commits the container to a new image.
+
+
+Args:
+    image: Tarball of image to run commands on.
+    commands: A list of commands to run (sequentially) in the container.
+    _run_tpl: Template for generated script to run docker commands.
+    _image_loader: A script to load a tar ball into docker while also remembering its name/id
+"""
+container_run_and_commit = rule(
     attrs = {
-        "image_tar": attr.label(
+        "image": attr.label(
             allow_files = True,
             mandatory = True,
             single_file = True,
             cfg = "target",
-        ),
-        "image_name": attr.string(
-            doc = "name of image to run commands on",
-            mandatory = True,
         ),
         "commands": attr.string_list(
             doc = "commands to run",
@@ -216,6 +198,11 @@ _run_and_commit = rule(
             allow_files = True,
             single_file = True,
         ),
+        "_image_loader": attr.label(
+          default = "//util:image_loader.sh",
+          allow_files = True,
+          single_file = True,
+        ),
     },
     executable = False,
     outputs = {
@@ -223,39 +210,6 @@ _run_and_commit = rule(
     },
     implementation = _commit_impl,
 )
-
-"""Runs commands in a container and commits the container to a new image.
-
-This rule runs a set of commands in a given image, waits for the commands
-to finish, and then commits the container to a new image.
-
-
-Args:
-    image_name: Name of the image to run commands on.
-    image_tar: Tarball of image to run commands on.
-    commands: A list of commands to run (sequentially) in the container.
-    _run_tpl: Template for generated script to run docker commands.
-"""
-
-def container_run_and_commit(name, image, commands):
-    """Macro to wrap the run_and_commit implementation.
-
-    This rule runs a set of commands in a given image, waits for the commands
-    to finish, and then commits the container to a new image.
-
-    Args:
-        name: A unique name for this rule.
-        image: The image to run the commands in.
-        commands: A list of commands to run (sequentially) in the container.
-    """
-    image_tar, intermediate_image = _rename_image(image, name)
-
-    _run_and_commit(
-        name = name,
-        image_name = intermediate_image,
-        image_tar = image_tar + ".tar",
-        commands = commands,
-    )
 
 def _process_commands(command_list):
     # Use the $ to allow escape characters in string


### PR DESCRIPTION
Also removed now redundant macros from run.bzl