### PR TITLE
Update debian snapshot for ncurses and procps CVEs

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -76,13 +76,13 @@ load(
 package_manager_repositories()
 
 # The Debian snapshot datetime to use. See http://snapshot.debian.org/ for more information.
-DEB_SNAPSHOT = "20180529T150320Z"
+DEB_SNAPSHOT = "20180625T203737Z"
 
 dpkg_src(
     name = "debian_jessie",
     arch = "amd64",
     distro = "jessie",
-    sha256 = "20720c9367e9454dee3d173e4d3fd85ab5530292f4ec6654feb5a810b6bb37ce",
+    sha256 = "7240a1c6ce11c3658d001261e77797818e610f7da6c2fb1f98a24fdbf4e8d84c",
     snapshot = DEB_SNAPSHOT,
     url = "http://snapshot.debian.org/archive",
 )

--- a/debian/reproducible/BUILD
+++ b/debian/reproducible/BUILD
@@ -9,7 +9,7 @@ load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 # TODO: Try to reuse this variable from WORKSPACE.
 # The Debian snapshot datetime to use. See http://snapshot.debian.org/ for more information.
-DEB_SNAPSHOT = "20180529T150320Z"
+DEB_SNAPSHOT = "20180625T203737Z"
 
 docker_build(
     name = "builder",

--- a/debian/reproducible/README.md
+++ b/debian/reproducible/README.md
@@ -8,10 +8,10 @@ every time.
 
 ### Usage
 
-Use `gcloud container builds submit --config=reproducible/cloudbuild.yaml .`
+Use `gcloud container builds submit --config=debian/reproducible/cloudbuild.yaml .`
 to build the image in the cloud.
-To build locally, use: `bazel build //reproducible:debian8`.
-To run tests locally, use: `bazel test //reproducible:debian8_test`.
+To build locally, use: `bazel build //debian/reproducible:debian8`.
+To run tests locally, use: `bazel test //debian/reproducible:debian8_test`.
 
 
 ### Process
@@ -33,4 +33,6 @@ See the `mkimage.sh` script for this portion of the process.
 #### Updates
 
 To update the debian package versions used in the build,
-modify the `SNAPSHOT` variable in the `BUILD` file in this directory.
+modify the `DEB_SNAPSHOT` variable in the top-level `WORKSPACE` file
+(along with its accompanying SHA256 checksum),
+as well as in the `BUILD` file in this directory.


### PR DESCRIPTION
ncurses:  `5.9 20140913-1+deb8u3` from `5.9 20140913-1+deb8u2`
procps: `2:3.3.9-9 deb8u1` from `2:3.3.9-9`

```
➜  container-diff diff daemon://bazel/debian/reproducible:debian8 remote://gcr.io/google-appengine/debian8:latest

-----Apt-----

Version differences:
PACKAGE              IMAGE1 (bazel/debian/reproducible:debian8)        IMAGE2 (gcr.io/google-appengine/debian8:latest)
-base-files          8 deb8u11, 413K                                   8 deb8u10, 413K
-gnupg               1.4.18-7 deb8u5, 4.8M                             1.4.18-7 deb8u4, 4.8M
-gpgv                1.4.18-7 deb8u5, 414K                             1.4.18-7 deb8u4, 414K
-libncurses5         5.9 20140913-1+deb8u3, 270K                       5.9 20140913-1+deb8u2, 270K
-libncursesw5        5.9 20140913-1+deb8u3, 353K                       5.9 20140913-1+deb8u2, 353K
-libprocps3          2:3.3.9-9 deb8u1, 105K                            2:3.3.9-9, 132K
-libtinfo5           5.9 20140913-1+deb8u3, 441K                       5.9 20140913-1+deb8u2, 441K
-ncurses-base        5.9 20140913-1+deb8u3, 372K                       5.9 20140913-1+deb8u2, 372K
-ncurses-bin         5.9 20140913-1+deb8u3, 493K                       5.9 20140913-1+deb8u2, 493K
-perl-base           5.20.2-3 deb8u11, 5M                              5.20.2-3 deb8u10, 4.5M
-procps              2:3.3.9-9 deb8u1, 577K                            2:3.3.9-9, 670K
-tzdata              2018e-0 deb8u1, 1.7M                              2018d-0 deb8u1, 1.7M
```