### PR TITLE
Fix container_image provider.

### DIFF
--- a/package_managers/apt_key.bzl
+++ b/package_managers/apt_key.bzl
@@ -83,7 +83,7 @@ def _impl(ctx, name=None, keys=None, image_tar=None, gpg_image=None, output_exec
 
     # Build the final image with additional gpg keys in it.
 
-    result = _container.image.implementation(
+    return _container.image.implementation(
         ctx,
         name=name,
         base=image_tar,
@@ -93,11 +93,6 @@ def _impl(ctx, name=None, keys=None, image_tar=None, gpg_image=None, output_exec
         output_tarball=output_tarball,
         output_layer=output_layer
     )
-
-    return struct(runfiles = result.runfiles,
-                  files = result.files,
-                  container_parts = result.container_parts)
-
 
 _attrs = dict(_container.image.attrs)
 _attrs.update(_extract.attrs)


### PR DESCRIPTION
https://github.com/bazelbuild/rules_docker/commit/0d6d69a2a4bbc33fc61a8350897b0e8136491ad5
changes the return value of container_image rule's implementation.