### PR TITLE
Pass in output digest name when calling container_image

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,9 +25,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Docker rules.
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "b4775b7c4fc76e3113dab643ee35eefbabca0b44908d0d1c85dcf29cab7c0638",
-    strip_prefix = "rules_docker-c7a93454d27e09ef707dfca53887ed0ff4372f04",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/c7a93454d27e09ef707dfca53887ed0ff4372f04.tar.gz"],
+    sha256 = "d9ee70d2f763ce197e2691f12d69ee8e32b2245a48d53b4365fa239b66405c0c",
+    strip_prefix = "rules_docker-7391b39ccad788524262e106d54adfdbfc3e44d5",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/7391b39ccad788524262e106d54adfdbfc3e44d5.tar.gz"],
 )
 
 load(

--- a/package_managers/apt_key.bzl
+++ b/package_managers/apt_key.bzl
@@ -17,7 +17,9 @@
 load("@io_bazel_rules_docker//container:container.bzl", _container = "container")
 load("@base_images_docker//util:run.bzl", _extract = "extract")
 
-def _impl(ctx, name=None, keys=None, image_tar=None, gpg_image=None, output_executable=None, output_tarball=None, output_layer=None):
+def _impl(ctx, name=None, keys=None, image_tar=None, gpg_image=None,
+    output_executable=None, output_tarball=None, output_layer=None,
+    output_digest=None):
     """Implementation for the add_apt_key rule.
 
     Args:
@@ -30,6 +32,7 @@ def _impl(ctx, name=None, keys=None, image_tar=None, gpg_image=None, output_exec
             overrides ctx.outputs.executable
         output_tarball: File, overrides ctx.outputs.out
         output_layer: File, overrides ctx.outputs.layer
+        output_digest: File, overrides ctx.outputs.digest
     """
     name = name or ctx.label.name
     keys = keys or ctx.files.keys
@@ -38,6 +41,7 @@ def _impl(ctx, name=None, keys=None, image_tar=None, gpg_image=None, output_exec
     output_executable = output_executable or ctx.outputs.executable
     output_tarball = output_tarball or ctx.outputs.out
     output_layer = output_layer or ctx.outputs.layer
+    output_digest = output_digest or ctx.outputs.digest
 
     # First build an image capable of adding an apt-key.
     # This requires the keyfile and the "gnupg package."
@@ -51,6 +55,7 @@ def _impl(ctx, name=None, keys=None, image_tar=None, gpg_image=None, output_exec
     key_image_output_executable = ctx.actions.declare_file("%s" % key_image)
     key_image_output_tarball = ctx.actions.declare_file("%s.tar" % key_image)
     key_image_output_layer = ctx.actions.declare_file("%s-layer.tar" % key_image)
+    key_image_output_digest = ctx.actions.declare_file("%s.digest" % key_image)
 
     key_image_result = _container.image.implementation(
         ctx,
@@ -60,7 +65,8 @@ def _impl(ctx, name=None, keys=None, image_tar=None, gpg_image=None, output_exec
         files=keys,
         output_executable=key_image_output_executable,
         output_tarball=key_image_output_tarball,
-        output_layer=key_image_output_layer
+        output_layer=key_image_output_layer,
+        output_digest=key_image_output_digest,
     )
 
     commands = [
@@ -91,7 +97,8 @@ def _impl(ctx, name=None, keys=None, image_tar=None, gpg_image=None, output_exec
         files=[extract_file_out],
         output_executable=output_executable,
         output_tarball=output_tarball,
-        output_layer=output_layer
+        output_layer=output_layer,
+        output_digest=output_digest,
     )
 
 _attrs = dict(_container.image.attrs)


### PR DESCRIPTION
Needed to fix breakage in bazel-toolchains because of https://github.com/bazelbuild/rules_docker/commit/9fd09b30ab07f224ff3a7455c44b58154c0e2e5b

The "install" rule in base-images-docker generates actions with conflicting outputs due to this new implicit output in container_image in rules_docker. This PR ensures the container_image properly overrides the digest name to avoid this conflict