### PR TITLE
Wait for container to finish in run_and_commit

### DIFF
--- a/util/commit.sh.tpl
+++ b/util/commit.sh.tpl
@@ -10,8 +10,13 @@ image_id=$(python %{image_id_extractor_path} %{image_tar})
 docker load -i %{image_tar}
 
 id=$(docker run -d $image_id %{commands})
+# Actually wait for the container to finish running its commands
+retcode=$(docker wait $id)
+# Trigger a failure if the run had a non-zero exit status
+if [ $retcode != 0 ]; then
+  docker logs $id && false
+fi
 
 reset_cmd $image_id $id %{output_image}
-
 docker save %{output_image} -o %{output_tar}
 docker rm $id


### PR DESCRIPTION
@tejal29 @sharifelgamal container_run_and_commit doesn't actually wait for the container to finish running before it commits. This means the modifications made by long running commands won't be committed