### PR TITLE
The trigger runs in root, not in the directory of the cloudbuild.yaml.

### DIFF
--- a/centos/cloudbuild.yaml
+++ b/centos/cloudbuild.yaml
@@ -1,6 +1,6 @@
 steps:
 - name: 'docker'
-  args: ['build', '.', '-f', 'Dockerfile.build', '-t', 'builder']
+  args: ['build', '.', '-f', 'centos/Dockerfile.build', '-t', 'builder']
 - name: 'builder'
   args: ['/build.sh']
 - name: 'docker'


### PR DESCRIPTION
cc @sharifelgamal 