### PR TITLE
Bump debian snapshot

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -94,7 +94,7 @@ load(
 package_manager_repositories()
 
 # The Debian snapshot datetime to use. See http://snapshot.debian.org/ for more information.
-DEB_SNAPSHOT = "20180809T161705Z"
+DEB_SNAPSHOT = "20181113T170311Z"
 
 dpkg_src(
     name = "debian_jessie",

--- a/debian/reproducible/BUILD
+++ b/debian/reproducible/BUILD
@@ -9,7 +9,7 @@ load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 # TODO: Try to reuse this variable from WORKSPACE.
 # The Debian snapshot datetime to use. See http://snapshot.debian.org/ for more information.
-DEB_SNAPSHOT = "20180809T161705Z"
+DEB_SNAPSHOT = "20181113T170311Z"
 
 docker_build(
     name = "builder",


### PR DESCRIPTION
```
➜ container-diff diff daemon://bazel/debian/reproducible:debian9 remote://gcr.io/google-appengine/debian9:latest --type=apt

-----Apt-----

Packages found only in bazel/debian/reproducible:debian9: None

Packages found only in gcr.io/google-appengine/debian9:latest: None

Version differences:
PACKAGE             IMAGE1 (bazel/debian/reproducible:debian9)        IMAGE2 (gcr.io/google-appengine/debian9:latest)
-base-files         9.9 deb9u6, 333K                                  9.9 deb9u5, 333K
-gpgv               2.1.18-8~deb9u3, 721K                             2.1.18-8~deb9u2, 721K
-libsystemd0        232-25 deb9u6, 653K                               232-25 deb9u4, 653K
-libudev1           232-25 deb9u6, 223K                               232-25 deb9u4, 223K
-tzdata             2018g-0 deb9u1, 2.9M                              2018e-0 deb9u1, 2.9M
```
