### PR TITLE
The new version of bazel deprecated "git_repository" as a native rule.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -44,6 +44,8 @@ load(
     "docker_repositories",
 )
 
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
 git_repository(
     name = "bazel_skylib",
     remote = "https://github.com/bazelbuild/bazel-skylib.git",


### PR DESCRIPTION
Load the new one.