### PR TITLE
Update ubuntu snapshots

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -153,12 +153,12 @@ go_register_toolchains()
 
 UBUNTU_MAP = {
     "16_0_4": {
-        "sha256": "0a2bdf709d126190df655de26398cfe9cbeafac907960e8075107eaf6e3eb21d",
-        "url": "https://storage.googleapis.com/ubuntu_tar/20181126/ubuntu-xenial-core-cloudimg-amd64-root.tar.gz",
+        "sha256": "73d2189d387b187001016657a062ff6f513889bc5f6c93f22dd3cec456adfa7e",
+        "url": "https://storage.googleapis.com/ubuntu_tar/20181217/ubuntu-xenial-core-cloudimg-amd64-root.tar.gz",
     },
     "18_0_4": {
-        "sha256": "a5eebfab0f6509c05de07d1817de63272b4e8b2db176426e83c4a4d21897ff39",
-        "url": "https://storage.googleapis.com/ubuntu_tar/20181126/ubuntu-bionic-core-cloudimg-amd64-root.tar.gz",
+        "sha256": "e63619b307b7f91983fa151f9c62f4f4263092e285913b8d2102a3717f572d48",
+        "url": "https://storage.googleapis.com/ubuntu_tar/20181204/ubuntu-bionic-core-cloudimg-amd64-root.tar.gz",
     },
 }
 

--- a/ubuntu/BUILD
+++ b/ubuntu/BUILD
@@ -57,16 +57,30 @@ genrule(
     tars = [":ubuntu_%s_vanilla_reproducible" % version],
 ) for version in UBUNTU_VERSIONS]
 
-[bootstrap_image_macro(
-    name = "bootstrap_ubuntu_%s" % version,
-    date = "20181126",
-    image_tar = ":ubuntu_%s_vanilla.tar" % version,
-    output_image_name = "ubuntu_%s" % version,
+bootstrap_image_macro(
+    name = "bootstrap_ubuntu_16_0_4",
+    date = "20181217",
+    image_tar = ":ubuntu_16_0_4_vanilla.tar",
+    output_image_name = "ubuntu_16_0_4",
     packages = [
         "ca-certificates",
         "curl",
         "libc-bin",
         "netbase",
     ],
-    store_location = "ubuntu/%s/builds" % version,
-) for version in UBUNTU_VERSIONS]
+    store_location = "ubuntu/16_0_4/builds",
+)
+
+bootstrap_image_macro(
+    name = "bootstrap_ubuntu_18_0_4",
+    date = "20181204",
+    image_tar = ":ubuntu_18_0_4_vanilla.tar",
+    output_image_name = "ubuntu_18_0_4",
+    packages = [
+        "ca-certificates",
+        "curl",
+        "libc-bin",
+        "netbase",
+    ],
+    store_location = "ubuntu/18_0_4/builds",
+)


### PR DESCRIPTION
The two versions have different timestamps for their latest snapshots, so they couldn't use the same bootstrap rule. I duplicated the rule for each version so they can have independent timestamps.