### PR TITLE
Bump ubuntu shapshots

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -163,12 +163,12 @@ go_register_toolchains()
 
 UBUNTU_MAP = {
     "16_0_4": {
-        "sha256": "73d2189d387b187001016657a062ff6f513889bc5f6c93f22dd3cec456adfa7e",
-        "url": "https://storage.googleapis.com/ubuntu_tar/20181217/ubuntu-xenial-core-cloudimg-amd64-root.tar.gz",
+        "sha256": "3f866f89c43af1d4e884807669082655a3c0fd7755b6fa588305e06781d72d0f",
+        "url": "https://storage.googleapis.com/ubuntu_tar/20190122/ubuntu-xenial-core-cloudimg-amd64-root.tar.gz",
     },
     "18_0_4": {
-        "sha256": "e63619b307b7f91983fa151f9c62f4f4263092e285913b8d2102a3717f572d48",
-        "url": "https://storage.googleapis.com/ubuntu_tar/20181204/ubuntu-bionic-core-cloudimg-amd64-root.tar.gz",
+        "sha256": "532cbbe3f77efb8723091e8727b0a01f9f18d71fba71e4dec81447b0b9aa851b",
+        "url": "https://storage.googleapis.com/ubuntu_tar/20190210/ubuntu-bionic-core-cloudimg-amd64-root.tar.gz",
     },
 }
 

--- a/tests/ubuntu/ubuntu_18_test.yaml
+++ b/tests/ubuntu/ubuntu_18_test.yaml
@@ -20,7 +20,7 @@ commandTests:
   excludedOutput: ['.*no packages found matching.*']
 fileContentTests:
 - name: 'Ubuntu Distro Check'
-  expectedContents: ['.*NAME="Ubuntu".*', '.*VERSION="18.04.1 LTS \(Bionic Beaver\)".*']
+  expectedContents: ['.*NAME="Ubuntu".*', '.*VERSION="18.04.2 LTS \(Bionic Beaver\)".*']
   path: '/etc/os-release'
 fileExistenceTests:
 - name: 'Root'

--- a/ubuntu/BUILD
+++ b/ubuntu/BUILD
@@ -59,7 +59,7 @@ genrule(
 
 bootstrap_image_macro(
     name = "bootstrap_ubuntu_16_0_4",
-    date = "20190129",
+    date = "20190122",
     image_tar = ":ubuntu_16_0_4_vanilla.tar",
     output_image_name = "ubuntu_16_0_4",
     packages = [
@@ -73,7 +73,7 @@ bootstrap_image_macro(
 
 bootstrap_image_macro(
     name = "bootstrap_ubuntu_18_0_4",
-    date = "20190128",
+    date = "20190210",
     image_tar = ":ubuntu_18_0_4_vanilla.tar",
     output_image_name = "ubuntu_18_0_4",
     packages = [


### PR DESCRIPTION
From local builds:

```
➜ container-diff diff daemon://gcr.io/gcp-runtimes/ubuntu_16_0_4:latest daemon://ubuntu_16:bazel --type=apt

-----Apt-----

Packages found only in gcr.io/gcp-runtimes/ubuntu_16_0_4:latest: None

Packages found only in ubuntu:bazel: None

Version differences:
PACKAGE                 IMAGE1 (gcr.io/gcp-runtimes/ubuntu_16_0_4:latest)        IMAGE2 (ubuntu:bazel)
-apt                    1.2.29, 3.3M                                             1.2.29ubuntu0.1, 3.3M
-curl                   7.47.0-1ubuntu2.11, 331K                                 7.47.0-1ubuntu2.12, 331K
-libapt-pkg5.0          1.2.29, 2.7M                                             1.2.29ubuntu0.1, 2.7M
-libcurl3-gnutls        7.47.0-1ubuntu2.11, 543K                                 7.47.0-1ubuntu2.12, 543K
-libsystemd0            229-4ubuntu21.10, 619K                                   229-4ubuntu21.15, 620K
-libudev1               229-4ubuntu21.10, 205K                                   229-4ubuntu21.15, 206K
-systemd                229-4ubuntu21.10, 18.3M                                  229-4ubuntu21.15, 18.5M
-systemd-sysv           229-4ubuntu21.10, 94K                                    229-4ubuntu21.15, 95K
```

```
➜ container-diff diff daemon://gcr.io/gcp-runtimes/ubuntu_18_0_4:latest daemon://ubuntu_18:bazel --type=apt

-----Apt-----

Packages found only in gcr.io/gcp-runtimes/ubuntu_18_0_4:latest: None

Packages found only in ubuntu_18:bazel: None

Version differences:
PACKAGE               IMAGE1 (gcr.io/gcp-runtimes/ubuntu_18_0_4:latest)        IMAGE2 (ubuntu_18:bazel)
-apt                  1.6.6, 3.7M                                              1.6.8, 3.7M
-base-files           10.1ubuntu2.3, 386K                                      10.1ubuntu2.4, 386K
-bsdutils             1:2.31.1-0.4ubuntu3.2, 264K                              1:2.31.1-0.4ubuntu3.3, 264K
-curl                 7.58.0-2ubuntu3.5, 386K                                  7.58.0-2ubuntu3.6, 386K
-e2fsprogs            1.44.1-1, 1.2M                                           1.44.1-1ubuntu1.1, 1.2M
-fdisk                2.31.1-0.4ubuntu3.2, 427K                                2.31.1-0.4ubuntu3.3, 427K
-gpgv                 2.2.4-1ubuntu1.1, 475K                                   2.2.4-1ubuntu1.2, 476K
-libapt-pkg5.0        1.6.6, 3M                                                1.6.8, 3M
-libblkid1            2.31.1-0.4ubuntu3.2, 398K                                2.31.1-0.4ubuntu3.3, 398K
-libcom-err2          1.44.1-1, 86K                                            1.44.1-1ubuntu1.1, 87K
-libcurl4             7.58.0-2ubuntu3.5, 626K                                  7.58.0-2ubuntu3.6, 626K
-libext2fs2           1.44.1-1, 451K                                           1.44.1-1ubuntu1.1, 452K
-libfdisk1            2.31.1-0.4ubuntu3.2, 508K                                2.31.1-0.4ubuntu3.3, 508K
-libmount1            2.31.1-0.4ubuntu3.2, 433K                                2.31.1-0.4ubuntu3.3, 433K
-libsmartcols1        2.31.1-0.4ubuntu3.2, 287K                                2.31.1-0.4ubuntu3.3, 287K
-libss2               1.44.1-1, 98K                                            1.44.1-1ubuntu1.1, 99K
-libsystemd0          237-3ubuntu10.9, 646K                                    237-3ubuntu10.12, 647K
-libudev1             237-3ubuntu10.9, 225K                                    237-3ubuntu10.12, 226K
-libuuid1             2.31.1-0.4ubuntu3.2, 116K                                2.31.1-0.4ubuntu3.3, 116K
-mount                2.31.1-0.4ubuntu3.2, 370K                                2.31.1-0.4ubuntu3.3, 370K
-tar                  1.29b-2, 864K                                            1.29b-2ubuntu0.1, 868K
-util-linux           2.31.1-0.4ubuntu3.2, 3.3M                                2.31.1-0.4ubuntu3.3, 3.3M
```