### PR TITLE
Updating ubuntu xenial to 16.04.6

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -163,8 +163,8 @@ go_register_toolchains()
 
 UBUNTU_MAP = {
     "16_0_4": {
-        "sha256": "3f866f89c43af1d4e884807669082655a3c0fd7755b6fa588305e06781d72d0f",
-        "url": "https://storage.googleapis.com/ubuntu_tar/20190122/ubuntu-xenial-core-cloudimg-amd64-root.tar.gz",
+        "sha256": "e39470d1389e65beea1ca188f79a069b27c06342de8f959f6ca799a8acbb80d3",
+        "url": "https://storage.googleapis.com/ubuntu_tar/20190222/ubuntu-xenial-core-cloudimg-amd64-root.tar.gz",
     },
     "18_0_4": {
         "sha256": "532cbbe3f77efb8723091e8727b0a01f9f18d71fba71e4dec81447b0b9aa851b",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -163,7 +163,7 @@ go_register_toolchains()
 
 UBUNTU_MAP = {
     "16_0_4": {
-        "sha256": "e39470d1389e65beea1ca188f79a069b27c06342de8f959f6ca799a8acbb80d3",
+        "sha256": "3eee1b642f67c045b085ba8745d0c077216dac2c28e69481e021f46453649af9",
         "url": "https://storage.googleapis.com/ubuntu_tar/20190222/ubuntu-xenial-core-cloudimg-amd64-root.tar.gz",
     },
     "18_0_4": {


### PR DESCRIPTION
-----Apt-----

Packages found only in gcr.io/gcp-runtimes/ubuntu_16_0_4:latest: None

Packages found only in bazel/ubuntu:bootstrap_ubuntu_16_0_4: None

Version differences:
PACKAGE                   IMAGE1 (gcr.io/gcp-runtimes/ubuntu_16_0_4:latest)        IMAGE2 (bazel/ubuntu:bootstrap_ubuntu_16_0_4)
-base-files               9.4ubuntu4.7, 312K                                       9.4ubuntu4.8, 312K
-libc6                    2.23-0ubuntu10, 10.7M                                    2.23-0ubuntu11, 10.7M
-libkmod2                 22-1ubuntu5.1, 118K                                      22-1ubuntu5.2, 118K
-libsystemd0              229-4ubuntu21.15, 620K                                   229-4ubuntu21.16, 620K
-libudev1                 229-4ubuntu21.15, 206K                                   229-4ubuntu21.16, 206K
-multiarch-support        2.23-0ubuntu10, 224K                                     2.23-0ubuntu11, 224K
-systemd                  229-4ubuntu21.15, 18.5M                                  229-4ubuntu21.16, 18.5M
-systemd-sysv             229-4ubuntu21.15, 95K                                    229-4ubuntu21.16, 95K

