### PR TITLE
Repair centos local build failure

### DIFF
--- a/centos/build.sh
+++ b/centos/build.sh
@@ -23,6 +23,6 @@ umount /target/proc/
 umount /target/sys/
 rm /target/chroot.sh
 
-tar -C /target -cf /workspace/centos/layer.tar .
+tar -C /target -cf /workspace/layer.tar .
 
 


### PR DESCRIPTION
CentOS image build fails with the instruction in "To build locally" section of centos/README.md.
The change repair it by correcting the relative directory. The problem, and the fix, may or may not apply to the gcloud though. 

Loaded plugins: fastestmirror, ovl
Cleaning repos: base extras updates
Cleaning up list of fastest mirrors
Locking password for user root.
passwd: Success
umount: /run: not mounted
tar: /workspace/centos/layer.tar: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now