### PR TITLE
Add epel release to centos to pick up security update provided by RedHat

### DIFF
--- a/centos/build.sh
+++ b/centos/build.sh
@@ -2,7 +2,7 @@
 
 # This script sets up a bootstrapped CentOS chroot and saves it as a tarball.
 
-mkdir /target
+mkdir -p /target
 rpm --nodeps --root /target/ -i http://mirror.centos.org/centos/7/os/x86_64/Packages/centos-release-7-6.1810.2.el7.centos.x86_64.rpm
 cp -f /etc/resolv.conf /target/etc
 

--- a/centos/chroot.sh
+++ b/centos/chroot.sh
@@ -3,6 +3,12 @@
 # This script runs inside a chroot and sets up a bootstrapped centos image.
 
 yum -y -q --releasever=7 install yum centos-release
+
+# ADD EPEL repo for extra packages (https://fedoraproject.org/wiki/EPEL)
+# This is to pick up extra packages including security updates provided by
+# RedHat
+yum -y install epel-release
+
 yum install -q -y bind-utils     bash     yum     vim-minimal     centos-release     less     iputils     iproute     systemd     rootfiles     tar     passwd     yum-utils     yum-plugin-ovl    hostname
 yum -q -y erase kernel*     *firmware     firewalld-filesystem     os-prober     gettext*     GeoIP     bind-license     freetype     libteam     teamd
 rpm -e kernel


### PR DESCRIPTION
The patch for libssh2 vulnerability is available in the EEPL mirror. 

Reading more about it, 
https://fedoraproject.org/wiki/EPEL#What_is_Extra_Packages_for_Enterprise_Linux_.28or_EPEL.29.3F

----
Extra Packages for Enterprise Linux (or EPEL) is a Fedora Special Interest Group that creates, maintains, and manages a high quality set of additional packages for Enterprise Linux, including, but not limited to, Red Hat Enterprise Linux (RHEL), CentOS and Scientific Linux (SL), Oracle Linux (OL).

EPEL packages are usually based on their Fedora counterparts and will never conflict with or replace packages in the base Enterprise Linux distributions. EPEL uses much of the same infrastructure as Fedora, including buildsystem, bugzilla instance, updates manager, mirror manager and more.

----