### PR TITLE
bump ubuntu snapshots

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -163,12 +163,12 @@ go_register_toolchains()
 
 UBUNTU_MAP = {
     "16_0_4": {
-        "sha256": "3eee1b642f67c045b085ba8745d0c077216dac2c28e69481e021f46453649af9",
-        "url": "https://storage.googleapis.com/ubuntu_tar/20190222/ubuntu-xenial-core-cloudimg-amd64-root.tar.gz",
+        "sha256": "e17b8c7a9d38c37e22a4498b0ff2e24fd30e15ce2fb6adae64c219d5d9a5ff4b",
+        "url": "https://storage.googleapis.com/ubuntu_tar/20190406/ubuntu-xenial-core-cloudimg-amd64-root.tar.gz",
     },
     "18_0_4": {
-        "sha256": "532cbbe3f77efb8723091e8727b0a01f9f18d71fba71e4dec81447b0b9aa851b",
-        "url": "https://storage.googleapis.com/ubuntu_tar/20190210/ubuntu-bionic-core-cloudimg-amd64-root.tar.gz",
+        "sha256": "65f7b277d131706107ba41d69468e31b0767420a01c8e5dec5ed9f15ff78fd9e",
+        "url": "https://storage.googleapis.com/ubuntu_tar/20190408/ubuntu-bionic-core-cloudimg-amd64-root.tar.gz",
     },
 }
 

--- a/ubuntu/BUILD
+++ b/ubuntu/BUILD
@@ -15,10 +15,17 @@ UBUNTU_ENV = {
     "DEBIAN_FRONTEND": "noninteractive",
 }
 
-# 'ubuntu_16_0_4' is a ubuntu_%s rootfs w/ ca-certificates, curl, and netbase
+# 'ubuntu_16_0_4' is a ubuntu_16_0_4 rootfs w/ ca-certificates, curl, and netbase
 dockerfile_build(
     name = "ubuntu_16_0_4",
     base = ":ubuntu_16_0_4_vanilla",
+    dockerfile = ":Dockerfile.ubuntu",
+)
+
+# 'ubuntu_18_0_4' is a ubuntu_18_0_4 rootfs w/ ca-certificates, curl, and netbase
+dockerfile_build(
+    name = "ubuntu_18_0_4",
+    base = ":ubuntu_18_0_4_vanilla",
     dockerfile = ":Dockerfile.ubuntu",
 )
 
@@ -59,7 +66,7 @@ genrule(
 
 bootstrap_image_macro(
     name = "bootstrap_ubuntu_16_0_4",
-    date = "20190301",
+    date = "20190409",
     image_tar = ":ubuntu_16_0_4_vanilla.tar",
     output_image_name = "ubuntu_16_0_4",
     packages = [
@@ -73,7 +80,7 @@ bootstrap_image_macro(
 
 bootstrap_image_macro(
     name = "bootstrap_ubuntu_18_0_4",
-    date = "20190301",
+    date = "20190406",
     image_tar = ":ubuntu_18_0_4_vanilla.tar",
     output_image_name = "ubuntu_18_0_4",
     packages = [


### PR DESCRIPTION
No CVEs in the 16.0.4 image currently, but bumping it anyway

```
➜  container-diff diff daemon://gcr.io/gcp-runtimes/ubuntu_16_0_4:latest daemon://bazel/ubuntu:ubuntu_16_0_4 --type=apt

-----Apt-----

Packages found only in gcr.io/gcp-runtimes/ubuntu_16_0_4:latest: None

Packages found only in bazel/ubuntu:ubuntu_16_0_4: None

Version differences:
PACKAGE               IMAGE1 (gcr.io/gcp-runtimes/ubuntu_16_0_4:latest)        IMAGE2 (bazel/ubuntu:ubuntu_16_0_4)
-apt                  1.2.29ubuntu0.1, 3.3M                                    1.2.31, 3.4M
-libapt-pkg5.0        1.2.29ubuntu0.1, 2.7M                                    1.2.31, 2.8M
-libsystemd0          229-4ubuntu21.16, 620K                                   229-4ubuntu21.21, 620K
-libudev1             229-4ubuntu21.16, 206K                                   229-4ubuntu21.21, 206K
-systemd              229-4ubuntu21.16, 18.5M                                  229-4ubuntu21.21, 18.5M
-systemd-sysv         229-4ubuntu21.16, 95K                                    229-4ubuntu21.21, 95K
```

```
➜  container-diff diff daemon://gcr.io/gcp-runtimes/ubuntu_18_0_4:latest daemon://bazel/ubuntu:ubuntu_18_0_4 --type=apt

-----Apt-----

Packages found only in gcr.io/gcp-runtimes/ubuntu_18_0_4:latest: None

Packages found only in bazel/ubuntu:ubuntu_18_0_4: None

Version differences:
PACKAGE                    IMAGE1 (gcr.io/gcp-runtimes/ubuntu_18_0_4:latest)        IMAGE2 (bazel/ubuntu:ubuntu_18_0_4)
-apt                       1.6.8, 3.7M                                              1.6.10, 3.7M
-libapt-pkg5.0             1.6.8, 3M                                                1.6.10, 3.1M
-libpam-modules            1.1.8-3.6ubuntu2, 912K                                   1.1.8-3.6ubuntu2.18.04.1, 916K
-libpam-modules-bin        1.1.8-3.6ubuntu2, 267K                                   1.1.8-3.6ubuntu2.18.04.1, 267K
-libpam-runtime            1.1.8-3.6ubuntu2, 300K                                   1.1.8-3.6ubuntu2.18.04.1, 300K
-libpam0g                  1.1.8-3.6ubuntu2, 212K                                   1.1.8-3.6ubuntu2.18.04.1, 212K
-libseccomp2               2.3.1-2.1ubuntu4, 293K                                   2.3.1-2.1ubuntu4.1, 301K
-libsystemd0               237-3ubuntu10.12, 647K                                   237-3ubuntu10.19, 647K
-libudev1                  237-3ubuntu10.12, 226K                                   237-3ubuntu10.19, 226K
-libunistring2             0.9.9-0ubuntu1, 1.5M                                     0.9.9-0ubuntu2, 1.5M
```