### PR TITLE
Add script to upload latest Ubuntu image to GCS

### DIFF
--- a/ubuntu/scripts/upload-latest.sh
+++ b/ubuntu/scripts/upload-latest.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+#
+# Safely copy the latest image for an Ubuntu version to GCS
+#
+# Usage:
+#   upload_latest.sh 16_0_4
+#
+# Debugging Usage:
+#   bash -x upload_latest.sh 16_0_4
+#
+set -eu -o pipefail
+
+readonly VERSION=$1
+readonly GCS_BUCKET="gs://ubuntu_tar"
+
+case $VERSION in
+  16_0_4)
+    readonly release="xenial"
+    ;;
+  18_0_4)
+    readonly release="bionic"
+    ;;
+  *)
+    echo "Unknown version: $VERSION"
+    exit 1
+    ;;
+esac
+
+readonly TMP_DIR=/tmp/${release}/$(date '+%Y-%m-%d')
+mkdir -p "${TMP_DIR}"
+cd "${TMP_DIR}"
+echo "Temp directory: ${TMP_DIR}"
+
+
+readonly base_url="https://partner-images.canonical.com/core/${release}/current"
+curl -OR "${base_url}/SHA256SUMS"
+readonly archive="ubuntu-${release}-core-cloudimg-amd64-root.tar.gz"
+curl -OR "${base_url}/${archive}"
+
+sha256sum --ignore-missing -c SHA256SUMS || exit 9
+
+# NOTE: Build dates are in GMT
+readonly build=$(TZ=Z stat -c '%y' "${archive}" | cut -d" " -f1 | sed s/-//g)
+readonly dest="${GCS_BUCKET}/${build}/${archive}"
+gsutil cp "${archive}" "${dest}"
+
+echo "Copy completed!"
+echo ""
+echo "Version:    ${VERSION} (${release})"
+echo "Location:   ${dest}"
+echo "Build date: ${build}"
+echo "SHA256SUM:  $(sha256sum ${archive} | awk '{ print $1 }')"
+
+
+


### PR DESCRIPTION
This is intended to take some toil and room for error out of our playbook entry.