### PR TITLE
Update xenial to 20190425

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -162,9 +162,9 @@ go_rules_dependencies()
 go_register_toolchains()
 
 UBUNTU_MAP = {
-    "16_0_4": {
-        "sha256": "e17b8c7a9d38c37e22a4498b0ff2e24fd30e15ce2fb6adae64c219d5d9a5ff4b",
-        "url": "https://storage.googleapis.com/ubuntu_tar/20190406/ubuntu-xenial-core-cloudimg-amd64-root.tar.gz",
+   "16_0_4": {
+        "sha256": "fd9e05a2b68f63eaf4cc25033d2cb0589882c24397d4cf2e5068c4049cc1763e",
+        "url": "https://storage.googleapis.com/ubuntu_tar/20190425/ubuntu-xenial-core-cloudimg-amd64-root.tar.gz",
     },
     "18_0_4": {
         "sha256": "65f7b277d131706107ba41d69468e31b0767420a01c8e5dec5ed9f15ff78fd9e",
@@ -189,3 +189,4 @@ http_file(
     sha256 = "54b6274820df34a936ccc6f5cb725a9b7bb46075db7faf0ef7e2d86452fa09fd",
     urls = ["http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0xEB9B1D8886F44E2A"],
 )
+


### PR DESCRIPTION
Updated WORKSPACE generated by script in #299

Internal issue ref: 131401908

```
----Apt-----

Packages found only in bazel/ubuntu:bootstrap_ubuntu_16_0_4: None

Packages found only in gcr.io/gcp-runtimes/ubuntu_16_0_4:latest: None

Version differences:
PACKAGE                 IMAGE1 (bazel/ubuntu:bootstrap_ubuntu_16_0_4)        IMAGE2 (gcr.io/gcp-runtimes/ubuntu_16_0_4:latest)                                                                                        
-ca-certificates        20170717~16.04.2, 426K                               20170717~16.04.1, 426K
-gcc-5-base             5.4.0-6ubuntu1~16.04.11, 66K                         5.4.0-6ubuntu1~16.04.10, 66K
-libssl1.0.0            1.0.2g-1ubuntu4.14, 3.3M                             1.0.2g-1ubuntu4.13, 3.3M
-libstdc++6             5.4.0-6ubuntu1~16.04.11, 1.9M                        5.4.0-6ubuntu1~16.04.10, 1.9M
-libsystemd0            229-4ubuntu21.10, 619K                               229-4ubuntu21.9, 619K
-libudev1               229-4ubuntu21.10, 205K                               229-4ubuntu21.9, 205K
-openssl                1.0.2g-1ubuntu4.14, 934K                             1.0.2g-1ubuntu4.13, 934K
-perl-base              5.22.1-9ubuntu0.6, 6.9M                              5.22.1-9ubuntu0.5, 6.9M
-systemd                229-4ubuntu21.10, 18.3M                              229-4ubuntu21.9, 18.5M
-systemd-sysv           229-4ubuntu21.10, 94K                                229-4ubuntu21.9, 94K
```