### PR TITLE
use new output_config attr properly

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -33,9 +33,9 @@ git_repository(
 # Docker rules.
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "5a35957ca26460137700985a224d83d8ec123a0c0643d648580e6925e5562a45",
-    strip_prefix = "rules_docker-0989f6251cbd4fede653ca415c386bee9ee7e64a",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/0989f6251cbd4fede653ca415c386bee9ee7e64a.tar.gz"],
+    sha256 = "1a035f4e9c21e48668e09b327f89bd8197feb42b82d2b6904913c655f27a845a",
+    strip_prefix = "rules_docker-bb6d6606a6be348115af3552662799fd6d851a88",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/bb6d6606a6be348115af3552662799fd6d851a88.tar.gz"],
 )
  # Register the docker toolchain type
 register_toolchains(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -33,9 +33,9 @@ git_repository(
 # Docker rules.
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "7355a42f93f4aecee147a734d1be9b91427d7fbf12292806cbdb22a3805011b9",
-    strip_prefix = "rules_docker-ea702043f0e59921a2a4dafaed8ac60c68011bbc",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/ea702043f0e59921a2a4dafaed8ac60c68011bbc.tar.gz"],
+    sha256 = "5a35957ca26460137700985a224d83d8ec123a0c0643d648580e6925e5562a45",
+    strip_prefix = "rules_docker-0989f6251cbd4fede653ca415c386bee9ee7e64a",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/0989f6251cbd4fede653ca415c386bee9ee7e64a.tar.gz"],
 )
  # Register the docker toolchain type
 register_toolchains(

--- a/package_managers/apt_key.bzl
+++ b/package_managers/apt_key.bzl
@@ -26,7 +26,8 @@ def _impl(
         output_executable = None,
         output_tarball = None,
         output_layer = None,
-        output_digest = None):
+        output_digest = None,
+        output_config = None):
     """Implementation for the add_apt_key rule.
 
     Args:
@@ -40,6 +41,7 @@ def _impl(
         output_tarball: File, overrides ctx.outputs.out
         output_layer: File, overrides ctx.outputs.layer
         output_digest: File, overrides ctx.outputs.digest
+        output_config: File, overrides ctx.outputs.config
     """
     name = name or ctx.label.name
     keys = keys or ctx.files.keys
@@ -49,6 +51,7 @@ def _impl(
     output_tarball = output_tarball or ctx.outputs.out
     output_layer = output_layer or ctx.outputs.layer
     output_digest = output_digest or ctx.outputs.digest
+    output_config = output_config or ctx.outputs.config
 
     # First build an image capable of adding an apt-key.
     # This requires the keyfile and the "gnupg package."
@@ -63,6 +66,7 @@ def _impl(
     key_image_output_tarball = ctx.actions.declare_file("%s.tar" % key_image)
     key_image_output_layer = ctx.actions.declare_file("%s-layer.tar" % key_image)
     key_image_output_digest = ctx.actions.declare_file("%s.digest" % key_image)
+    key_image_output_config = ctx.actions.declare_file("%s.json" % key_image)
 
     key_image_result = _container.image.implementation(
         ctx,
@@ -74,6 +78,7 @@ def _impl(
         output_tarball = key_image_output_tarball,
         output_layer = key_image_output_layer,
         output_digest = key_image_output_digest,
+        output_config = key_image_output_config,
     )
 
     commands = [
@@ -107,6 +112,7 @@ def _impl(
         output_tarball = output_tarball,
         output_layer = output_layer,
         output_digest = output_digest,
+        output_config = output_config,
     )
 
 _attrs = dict(_container.image.attrs)


### PR DESCRIPTION
https://github.com/bazelbuild/rules_docker/pull/818 added a new
output_config attr that must be properly overriden in apt_key

This PR depends on https://github.com/GoogleContainerTools/base-images-docker/pull/306 (which updates pin to rules_docker to after PR 818 linked above)