### PR TITLE
Bump dependency pins and some clean up.

### DIFF
--- a/debian9/WORKSPACE
+++ b/debian9/WORKSPACE
@@ -18,23 +18,23 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "bazel_toolchains",
-    sha256 = "91db7cf3a400da264e9123bb3d070e80184d9e40a87fc38b50e1dbb002b212fc",
-    strip_prefix = "bazel-toolchains-db36179f00b0b252a80824ed7dabc636c5e6c5fe",
-    urls = ["https://github.com/bazelbuild/bazel-toolchains/archive/db36179f00b0b252a80824ed7dabc636c5e6c5fe.tar.gz"],
+    sha256 = "e886e0624871dcce823cccc7f9a634c58b0d68fdc3ad6577347826558f1581d8",
+    strip_prefix = "bazel-toolchains-9f6cd65b5fd8bc85634dafc99075556c06d8d3a6",
+    urls = ["https://github.com/bazelbuild/bazel-toolchains/archive/9f6cd65b5fd8bc85634dafc99075556c06d8d3a6.tar.gz"],
 )
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "4abb48f56b838957c9c72ac511b44f79612fcf39d08338fad14a8e3f6b0572ea",
-    strip_prefix = "rules_docker-b8ff6a85ec359db3fd5657accd3e524daf12016d",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/b8ff6a85ec359db3fd5657accd3e524daf12016d.tar.gz"],
+    sha256 = "1a035f4e9c21e48668e09b327f89bd8197feb42b82d2b6904913c655f27a845a",
+    strip_prefix = "rules_docker-bb6d6606a6be348115af3552662799fd6d851a88",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/bb6d6606a6be348115af3552662799fd6d851a88.tar.gz"],
 )
 
 http_archive(
     name = "base_images_docker",
-    sha256 = "26b6eb32e19deee8782bd734a2214c6a33dd5ec5b9fb3e92c69a2d5896ad89e3",
-    strip_prefix = "base-images-docker-6830adea69c63a5bf3cf8b93b2f5e56422181839",
-    urls = ["https://github.com/GoogleContainerTools/base-images-docker/archive/6830adea69c63a5bf3cf8b93b2f5e56422181839.tar.gz"],
+    sha256 = "16da54ef0734a0658d7006bc8bf6b9be26b963edec497b13974a1bfb46cefc41",
+    strip_prefix = "base-images-docker-7fdd2bb83a6957fe66712bd5238087b257b04378",
+    urls = ["https://github.com/GoogleContainerTools/base-images-docker/archive/7fdd2bb83a6957fe66712bd5238087b257b04378.tar.gz"],
 )
 
 http_archive(

--- a/debian9/cloudbuild.yaml
+++ b/debian9/cloudbuild.yaml
@@ -14,53 +14,53 @@
 
 timeout: 21600s
 options:
-    machineType: 'N1_HIGHCPU_32'
+    machineType: "N1_HIGHCPU_32"
 
 steps:
 # Step: print the bazel version for record
-  - name: 'gcr.io/asci-toolchain/nosla-ubuntu16_04-bazel-docker-gcloud:latest'
-    args: ['bazel', 'version']
-    id: 'version'
-    waitFor: ['-']   # wait for nothing - start immediately
+  - name: "l.gcr.io/google/bazel"
+    args: ["version"]
+    id: "version"
+    waitFor: ["-"]   # wait for nothing - start immediately
 
 # Step: build the image
-  - name: 'gcr.io/asci-toolchain/nosla-ubuntu16_04-bazel-docker-gcloud:latest'
+  - name: "l.gcr.io/google/bazel"
     # Set Bazel output_base to /workspace, which is a mounted directory on Google Cloud Builder.
     # This is to make sure Bazel generated files can be accessed by multiple containers.
-    # TODO(xingao) Remove --loading_phase_threads=1. There is some race condition happening
-    # when multiple `gsutil cp` commands are called (by the gcs_file repository rule).
-    args: ['bazel', '--output_base=/workspace/debian9', 'run', '//:image', '--loading_phase_threads=1']
+    args: ["--output_base=/workspace/debian9", "run", "//:image"]
     # This is needed for GCB to correctly build/test targets in the Bazel project.
-    dir: 'debian9'
-    id: 'container-build'
-    waitFor: ['version']
+    dir: "debian9"
+    id: "container-build"
+    waitFor: ["version"]
 
 # Step: run structure tests on the new image
 # We use container_test rule, which is a Bazel wrapper of container_structure_test.
 # https://github.com/bazelbuild/rules_docker/blob/master/contrib/test.bzl
-  - name: 'gcr.io/asci-toolchain/nosla-ubuntu16_04-bazel-docker-gcloud:latest'
-    args: ['bazel', '--output_base=/workspace/debian9', 'test', '//:image-test', '--test_output=errors']
+  - name: "l.gcr.io/google/bazel"
+    args: ["--output_base=/workspace/debian9", "test", "//:image-test", "--test_output=errors"]
     # This is needed for GCB to correctly build/test targets in the Bazel project.
-    dir: 'debian9'
-    id: 'structure-test'
-    waitFor: ['container-build']
+    dir: "debian9"
+    id: "structure-test"
+    waitFor: ["container-build"]
 
 # Step: tag the image, first as the backup image.
-  - name: 'gcr.io/asci-toolchain/nosla-ubuntu16_04-bazel-docker-gcloud:latest'
-    args: ['docker', 'tag', 'bazel:image', 'gcr.io/asci-toolchain-backup/debian9-xingao-test:latest']
-    id: 'backup-container-tag'
-    waitFor: ['structure-test']
+  - name: "l.gcr.io/google/bazel"
+    entrypoint: "docker"
+    args: ["tag", "bazel:image", "gcr.io/asci-toolchain-backup/debian9-xingao-test:latest"]
+    id: "backup-container-tag"
+    waitFor: ["structure-test"]
 
 # Step: tag the image again with the final location.
-  - name: 'gcr.io/asci-toolchain/nosla-ubuntu16_04-bazel-docker-gcloud:latest'
-    args: ['docker', 'tag', 'bazel:image', 'gcr.io/asci-toolchain/debian9-xingao-test:latest']
-    id: 'container-tag'
-    waitFor: ['backup-container-tag']
+  - name: "l.gcr.io/google/bazel"
+    entrypoint: "docker"
+    args: ["tag", "bazel:image", "gcr.io/asci-toolchain/debian9-xingao-test:latest"]
+    id: "container-tag"
+    waitFor: ["backup-container-tag"]
 
 # Push the new image and its backup.
 # Push by using the `images` field here so they will show up in the build results
 # or the GCB Build information page.
 # https://cloud.google.com/cloud-build/docs/configuring-builds/store-images-artifacts
 images:
-  - 'gcr.io/asci-toolchain/debian9-xingao-test:latest'
-  - 'gcr.io/asci-toolchain-backup/debian9-xingao-test:latest'
+  - "gcr.io/asci-toolchain/debian9-xingao-test:latest"
+  - "gcr.io/asci-toolchain-backup/debian9-xingao-test:latest"

--- a/debian9/test.yaml
+++ b/debian9/test.yaml
@@ -1,3 +1,17 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 schemaVersion: '2.0.0'
 
 commandTests:
@@ -10,14 +24,7 @@ commandTests:
   command: 'apt-config'
   args: ['dump']
   expectedOutput: ['Acquire::Retries "3"']
-metadataTest:
-  env:
-        - key: PORT
-          value: 8080
-        - key: DEBIAN_FRONTEND
-          value: noninteractive
-        - key: PATH
-          value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
 fileContentTests:
 - name: 'Debian Sources'
   excludedContents: ['.*gce_debian_mirror.*']
@@ -26,6 +33,11 @@ fileContentTests:
 - name: 'Retry Policy'
   expectedContents: ['Acquire::Retries 3;']
   path: '/etc/apt/apt.conf.d/apt-retry'
+# Debian 9 specific tests.
+- name: 'Debian Sources Version'
+  expectedContents: ['stretch']
+  path: '/etc/apt/sources.list'
+
 fileExistenceTests:
 - name: 'Root'
   path: '/'
@@ -36,12 +48,16 @@ fileExistenceTests:
 - name: 'Machine ID'
   path: '/etc/machine-id'
   shouldExist: true
+
+metadataTest:
+  env:
+    - key: PORT
+      value: 8080
+    - key: DEBIAN_FRONTEND
+      value: noninteractive
+    - key: PATH
+      value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
 licenseTests:
 - debian: true
   files:
-
-# Debian 9 specific tests.
-fileContentTests:
-- name: 'Debian Sources Version'
-  expectedContents: ['stretch']
-  path: '/etc/apt/sources.list'

--- a/ubuntu1604/WORKSPACE
+++ b/ubuntu1604/WORKSPACE
@@ -22,23 +22,23 @@ load(
 
 http_archive(
     name = "bazel_toolchains",
-    sha256 = "91db7cf3a400da264e9123bb3d070e80184d9e40a87fc38b50e1dbb002b212fc",
-    strip_prefix = "bazel-toolchains-db36179f00b0b252a80824ed7dabc636c5e6c5fe",
-    urls = ["https://github.com/bazelbuild/bazel-toolchains/archive/db36179f00b0b252a80824ed7dabc636c5e6c5fe.tar.gz"],
+    sha256 = "e886e0624871dcce823cccc7f9a634c58b0d68fdc3ad6577347826558f1581d8",
+    strip_prefix = "bazel-toolchains-9f6cd65b5fd8bc85634dafc99075556c06d8d3a6",
+    urls = ["https://github.com/bazelbuild/bazel-toolchains/archive/9f6cd65b5fd8bc85634dafc99075556c06d8d3a6.tar.gz"],
 )
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "4abb48f56b838957c9c72ac511b44f79612fcf39d08338fad14a8e3f6b0572ea",
-    strip_prefix = "rules_docker-b8ff6a85ec359db3fd5657accd3e524daf12016d",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/b8ff6a85ec359db3fd5657accd3e524daf12016d.tar.gz"],
+    sha256 = "1a035f4e9c21e48668e09b327f89bd8197feb42b82d2b6904913c655f27a845a",
+    strip_prefix = "rules_docker-bb6d6606a6be348115af3552662799fd6d851a88",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/bb6d6606a6be348115af3552662799fd6d851a88.tar.gz"],
 )
 
 http_archive(
     name = "base_images_docker",
-    sha256 = "26b6eb32e19deee8782bd734a2214c6a33dd5ec5b9fb3e92c69a2d5896ad89e3",
-    strip_prefix = "base-images-docker-6830adea69c63a5bf3cf8b93b2f5e56422181839",
-    urls = ["https://github.com/GoogleContainerTools/base-images-docker/archive/6830adea69c63a5bf3cf8b93b2f5e56422181839.tar.gz"],
+    sha256 = "16da54ef0734a0658d7006bc8bf6b9be26b963edec497b13974a1bfb46cefc41",
+    strip_prefix = "base-images-docker-7fdd2bb83a6957fe66712bd5238087b257b04378",
+    urls = ["https://github.com/GoogleContainerTools/base-images-docker/archive/7fdd2bb83a6957fe66712bd5238087b257b04378.tar.gz"],
 )
 
 http_archive(

--- a/ubuntu1604/cloudbuild.yaml
+++ b/ubuntu1604/cloudbuild.yaml
@@ -14,53 +14,53 @@
 
 timeout: 21600s
 options:
-    machineType: 'N1_HIGHCPU_32'
+    machineType: "N1_HIGHCPU_32"
 
 steps:
 # Step: print the bazel version for record
-  - name: 'gcr.io/asci-toolchain/nosla-ubuntu16_04-bazel-docker-gcloud:latest'
-    args: ['bazel', 'version']
-    id: 'version'
-    waitFor: ['-']   # wait for nothing - start immediately
+  - name: "l.gcr.io/google/bazel"
+    args: ["version"]
+    id: "version"
+    waitFor: ["-"]   # wait for nothing - start immediately
 
 # Step: build the image
-  - name: 'gcr.io/asci-toolchain/nosla-ubuntu16_04-bazel-docker-gcloud:latest'
+  - name: "l.gcr.io/google/bazel"
     # Set Bazel output_base to /workspace, which is a mounted directory on Google Cloud Builder.
     # This is to make sure Bazel generated files can be accessed by multiple containers.
-    # TODO(xingao) Remove --loading_phase_threads=1. There is some race condition happening
-    # when multiple `gsutil cp` commands are called (by the gcs_file repository rule).
-    args: ['bazel', '--output_base=/workspace/ubuntu1604', 'run', '//:image', '--loading_phase_threads=1']
+    args: ["--output_base=/workspace/ubuntu1604", "run", "//:image"]
     # This is needed for GCB to correctly build/test targets in the Bazel project.
-    dir: 'ubuntu1604'
-    id: 'container-build'
-    waitFor: ['version']
+    dir: "ubuntu1604"
+    id: "container-build"
+    waitFor: ["version"]
 
 # Step: run structure tests on the new image
 # We use container_test rule, which is a Bazel wrapper of container_structure_test.
 # https://github.com/bazelbuild/rules_docker/blob/master/contrib/test.bzl
-  - name: 'gcr.io/asci-toolchain/nosla-ubuntu16_04-bazel-docker-gcloud:latest'
-    args: ['bazel', '--output_base=/workspace/ubuntu1604', 'test', '//:image-test']
+  - name: "l.gcr.io/google/bazel"
+    args: ["--output_base=/workspace/ubuntu1604", "test", "//:image-test"]
     # This is needed for GCB to correctly build/test targets in the Bazel project.
-    dir: 'ubuntu1604'
-    id: 'structure-test'
-    waitFor: ['container-build']
+    dir: "ubuntu1604"
+    id: "structure-test"
+    waitFor: ["container-build"]
 
 # Step: tag the image, first as the backup image.
-  - name: 'gcr.io/asci-toolchain/nosla-ubuntu16_04-bazel-docker-gcloud:latest'
-    args: ['docker', 'tag', 'bazel:image', 'gcr.io/asci-toolchain-backup/ubuntu1604-xingao-test:latest']
-    id: 'backup-container-tag'
-    waitFor: ['structure-test']
+  - name: "l.gcr.io/google/bazel"
+    entrypoint: "docker"
+    args: ["tag", "bazel:image", "gcr.io/asci-toolchain-backup/ubuntu1604-xingao-test:latest"]
+    id: "backup-container-tag"
+    waitFor: ["structure-test"]
 
 # Step: tag the image again with the final location.
-  - name: 'gcr.io/asci-toolchain/nosla-ubuntu16_04-bazel-docker-gcloud:latest'
-    args: ['docker', 'tag', 'bazel:image', 'gcr.io/asci-toolchain/ubuntu1604-xingao-test:latest']
-    id: 'container-tag'
-    waitFor: ['backup-container-tag']
+  - name: "l.gcr.io/google/bazel"
+    entrypoint: "docker"
+    args: ["tag", "bazel:image", "gcr.io/asci-toolchain/ubuntu1604-xingao-test:latest"]
+    id: "container-tag"
+    waitFor: ["backup-container-tag"]
 
 # Push the new image and its backup.
 # Push by using the `images` field here so they will show up in the build results
 # or the GCB Build information page.
 # https://cloud.google.com/cloud-build/docs/configuring-builds/store-images-artifacts
 images:
-  - 'gcr.io/asci-toolchain/ubuntu1604-xingao-test:latest'
-  - 'gcr.io/asci-toolchain-backup/ubuntu1604-xingao-test:latest'
+  - "gcr.io/asci-toolchain/ubuntu1604-xingao-test:latest"
+  - "gcr.io/asci-toolchain-backup/ubuntu1604-xingao-test:latest"

--- a/ubuntu1804/WORKSPACE
+++ b/ubuntu1804/WORKSPACE
@@ -22,23 +22,23 @@ load(
 
 http_archive(
     name = "bazel_toolchains",
-    sha256 = "91db7cf3a400da264e9123bb3d070e80184d9e40a87fc38b50e1dbb002b212fc",
-    strip_prefix = "bazel-toolchains-db36179f00b0b252a80824ed7dabc636c5e6c5fe",
-    urls = ["https://github.com/bazelbuild/bazel-toolchains/archive/db36179f00b0b252a80824ed7dabc636c5e6c5fe.tar.gz"],
+    sha256 = "e886e0624871dcce823cccc7f9a634c58b0d68fdc3ad6577347826558f1581d8",
+    strip_prefix = "bazel-toolchains-9f6cd65b5fd8bc85634dafc99075556c06d8d3a6",
+    urls = ["https://github.com/bazelbuild/bazel-toolchains/archive/9f6cd65b5fd8bc85634dafc99075556c06d8d3a6.tar.gz"],
 )
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "4abb48f56b838957c9c72ac511b44f79612fcf39d08338fad14a8e3f6b0572ea",
-    strip_prefix = "rules_docker-b8ff6a85ec359db3fd5657accd3e524daf12016d",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/b8ff6a85ec359db3fd5657accd3e524daf12016d.tar.gz"],
+    sha256 = "1a035f4e9c21e48668e09b327f89bd8197feb42b82d2b6904913c655f27a845a",
+    strip_prefix = "rules_docker-bb6d6606a6be348115af3552662799fd6d851a88",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/bb6d6606a6be348115af3552662799fd6d851a88.tar.gz"],
 )
 
 http_archive(
     name = "base_images_docker",
-    sha256 = "26b6eb32e19deee8782bd734a2214c6a33dd5ec5b9fb3e92c69a2d5896ad89e3",
-    strip_prefix = "base-images-docker-6830adea69c63a5bf3cf8b93b2f5e56422181839",
-    urls = ["https://github.com/GoogleContainerTools/base-images-docker/archive/6830adea69c63a5bf3cf8b93b2f5e56422181839.tar.gz"],
+    sha256 = "16da54ef0734a0658d7006bc8bf6b9be26b963edec497b13974a1bfb46cefc41",
+    strip_prefix = "base-images-docker-7fdd2bb83a6957fe66712bd5238087b257b04378",
+    urls = ["https://github.com/GoogleContainerTools/base-images-docker/archive/7fdd2bb83a6957fe66712bd5238087b257b04378.tar.gz"],
 )
 
 http_archive(

--- a/ubuntu1804/cloudbuild.yaml
+++ b/ubuntu1804/cloudbuild.yaml
@@ -14,53 +14,53 @@
 
 timeout: 21600s
 options:
-    machineType: 'N1_HIGHCPU_32'
+    machineType: "N1_HIGHCPU_32"
 
 steps:
 # Step: print the bazel version for record
-  - name: 'gcr.io/asci-toolchain/nosla-ubuntu16_04-bazel-docker-gcloud:latest'
-    args: ['bazel', 'version']
-    id: 'version'
-    waitFor: ['-']   # wait for nothing - start immediately
+  - name: "l.gcr.io/google/bazel"
+    args: ["version"]
+    id: "version"
+    waitFor: ["-"]   # wait for nothing - start immediately
 
 # Step: build the image
-  - name: 'gcr.io/asci-toolchain/nosla-ubuntu16_04-bazel-docker-gcloud:latest'
+  - name: "l.gcr.io/google/bazel"
     # Set Bazel output_base to /workspace, which is a mounted directory on Google Cloud Builder.
     # This is to make sure Bazel generated files can be accessed by multiple containers.
-    # TODO(xingao) Remove --loading_phase_threads=1. There is some race condition happening
-    # when multiple `gsutil cp` commands are called (by the gcs_file repository rule).
-    args: ['bazel', '--output_base=/workspace/ubuntu1804', 'run', '//:image', '--loading_phase_threads=1']
+    args: ["--output_base=/workspace/ubuntu1804", "run", "//:image"]
     # This is needed for GCB to correctly build/test targets in the Bazel project.
-    dir: 'ubuntu1804'
-    id: 'container-build'
-    waitFor: ['version']
+    dir: "ubuntu1804"
+    id: "container-build"
+    waitFor: ["version"]
 
 # Step: run structure tests on the new image
 # We use container_test rule, which is a Bazel wrapper of container_structure_test.
 # https://github.com/bazelbuild/rules_docker/blob/master/contrib/test.bzl
-  - name: 'gcr.io/asci-toolchain/nosla-ubuntu16_04-bazel-docker-gcloud:latest'
-    args: ['bazel', '--output_base=/workspace/ubuntu1804', 'test', '//:image-test']
+  - name: "l.gcr.io/google/bazel"
+    args: ["--output_base=/workspace/ubuntu1804", "test", "//:image-test"]
     # This is needed for GCB to correctly build/test targets in the Bazel project.
-    dir: 'ubuntu1804'
-    id: 'structure-test'
-    waitFor: ['container-build']
+    dir: "ubuntu1804"
+    id: "structure-test"
+    waitFor: ["container-build"]
 
 # Step: tag the image, first as the backup image.
-  - name: 'gcr.io/asci-toolchain/nosla-ubuntu16_04-bazel-docker-gcloud:latest'
-    args: ['docker', 'tag', 'bazel:image', 'gcr.io/asci-toolchain-backup/ubuntu1804-xingao-test:latest']
-    id: 'backup-container-tag'
-    waitFor: ['structure-test']
+  - name: "l.gcr.io/google/bazel"
+    entrypoint: "docker"
+    args: ["tag", "bazel:image", "gcr.io/asci-toolchain-backup/ubuntu1804-xingao-test:latest"]
+    id: "backup-container-tag"
+    waitFor: ["structure-test"]
 
 # Step: tag the image again with the final location.
-  - name: 'gcr.io/asci-toolchain/nosla-ubuntu16_04-bazel-docker-gcloud:latest'
-    args: ['docker', 'tag', 'bazel:image', 'gcr.io/asci-toolchain/ubuntu1804-xingao-test:latest']
-    id: 'container-tag'
-    waitFor: ['backup-container-tag']
+  - name: "l.gcr.io/google/bazel"
+    entrypoint: "docker"
+    args: ["tag", "bazel:image", "gcr.io/asci-toolchain/ubuntu1804-xingao-test:latest"]
+    id: "container-tag"
+    waitFor: ["backup-container-tag"]
 
 # Push the new image and its backup.
 # Push by using the `images` field here so they will show up in the build results
 # or the GCB Build information page.
 # https://cloud.google.com/cloud-build/docs/configuring-builds/store-images-artifacts
 images:
-  - 'gcr.io/asci-toolchain/ubuntu1804-xingao-test:latest'
-  - 'gcr.io/asci-toolchain-backup/ubuntu1804-xingao-test:latest'
+  - "gcr.io/asci-toolchain/ubuntu1804-xingao-test:latest"
+  - "gcr.io/asci-toolchain-backup/ubuntu1804-xingao-test:latest"


### PR DESCRIPTION
We installed docker in l.gcr.io/google/bazel, so now switch to that to generate containers.

Standardize to double quotation mark in cloudbuild.yaml files.