### PR TITLE
Add metadata CSV output for download_pkgs rule

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -36,6 +36,12 @@ file_test(
     regexp = ".*docker cp .*:test_download_pkgs_at_root_packages.tar test_download_pkgs_at_root.tar.*",
 )
 
+file_test(
+    name = "test_download_pkgs_at_root_metadata_csv",
+    file = ":test_download_pkgs_at_root_metadata.csv",
+    regexp = "curl",
+)
+
 sh_test(
     name = "download_pkgs_at_root_run_test",
     srcs = [":download_pkgs_at_root_run_test.sh"],

--- a/package_managers/download_pkgs.bzl
+++ b/package_managers/download_pkgs.bzl
@@ -90,9 +90,6 @@ def _impl(ctx, image_tar = None, packages = None, additional_repos = None, outpu
     output_script = output_script or ctx.outputs.build_script
     output_metadata = output_metadata or ctx.outputs.metadata_csv
 
-    print("output_tar: {}".format(output_tar))
-    print("output_metadata: {}".format(output_metadata))
-
     # Generate a shell script to run apt_get inside this docker image.
     # TODO(tejaldesai): Replace this by docker_run rule
     build_contents = """\

--- a/tests/package_managers/BUILD
+++ b/tests/package_managers/BUILD
@@ -41,6 +41,12 @@ file_test(
     regexp = ".*docker cp .*:test_download_pkgs_packages.tar tests/package_managers/test_download_pkgs.tar.*",
 )
 
+file_test(
+    name = "test_download_pkgs_metadata_csv",
+    file = ":test_download_pkgs",
+    regexp = "netbase",
+)
+
 sh_test(
     name = "download_pkgs_run_test",
     srcs = ["download_pkgs_run_test.sh"],
@@ -70,6 +76,12 @@ sh_test(
     name = "download_pkgs_with_additional_repos_run_test",
     srcs = ["download_pkgs_with_additional_repos_run_test.sh"],
     data = [":test_download_pkgs_with_additional_repos.tar"],
+)
+
+file_test(
+    name = "test_download_pkgs_with_additional_repos_metadata_csv",
+    file = ":test_download_pkgs_with_additional_repos_metadata.csv",
+    regexp = "bazel",
 )
 
 install_pkgs(
@@ -130,6 +142,12 @@ download_pkgs(
     packages = [
         "git",
     ],
+)
+
+file_test(
+    name = "test_download_pkg_git_metadata_csv",
+    file = ":download_pkg_git_metadata.csv",
+    regexp = "git",
 )
 
 install_pkgs(


### PR DESCRIPTION
The CSV file will list every package and their respective versions
included in the output tarball produced by the download_pkgs rule.