### PR TITLE
Use the default shell for docker commands

### DIFF
--- a/debian/reproducible/debootstrap.bzl
+++ b/debian/reproducible/debootstrap.bzl
@@ -58,6 +58,7 @@ docker rm $cid
         inputs=ctx.attr._builder_image.files.to_list() +
         ctx.attr._builder_image.data_runfiles.files.to_list() + ctx.attr._builder_image.default_runfiles.files.to_list(),
         executable=script,
+        use_default_shell_env = True,
     )
 
     return struct()

--- a/dockerfile_build/dockerfile_build.bzl
+++ b/dockerfile_build/dockerfile_build.bzl
@@ -87,6 +87,7 @@ docker save {tag} > {output}
         inputs=inputs,
         executable=script,
         mnemonic="BuildTar",
+        use_default_shell_env = True,
     )
 
 
@@ -96,6 +97,7 @@ docker save {tag} > {output}
         executable=ctx.executable._config_stripper,
         arguments=['--in_tar_path=%s' % unstripped_tar.path, '--out_tar_path=%s' % ctx.outputs.out.path],
         mnemonic="StripTar",
+        use_default_shell_env = True,
     )
 
     return struct()

--- a/package_managers/install_pkgs.bzl
+++ b/package_managers/install_pkgs.bzl
@@ -119,6 +119,7 @@ docker rm $cid""".format(util_script=ctx.file._image_utils.path,
     outputs=[unstripped_tar],
     inputs=[image_tar, install_script, installables_tar, ctx.file._image_utils, ctx.file._image_id_extractor],
     executable=script,
+    use_default_shell_env = True,
   )
 
   ctx.actions.run(
@@ -126,6 +127,7 @@ docker rm $cid""".format(util_script=ctx.file._image_utils.path,
     inputs=[unstripped_tar],
     executable=ctx.executable._config_stripper,
     arguments=['--in_tar_path=%s' % unstripped_tar.path, '--out_tar_path=%s' % output_tar.path],
+    use_default_shell_env = True,
   )
 
   return struct ()

--- a/util/run.bzl
+++ b/util/run.bzl
@@ -65,6 +65,7 @@ def _extract_impl(ctx, name = "", image = None, commands = None, docker_run_flag
         outputs = [output_file],
         tools = [image, ctx.file._image_id_extractor],
         executable = script,
+        use_default_shell_env = True,
     )
 
     return struct()
@@ -178,6 +179,7 @@ def _commit_impl(
         outputs = [output_image_tar],
         inputs = runfiles,
         executable = script,
+        use_default_shell_env = True,
     )
 
     return struct()


### PR DESCRIPTION
If you are not running docker locally, you need to set some
environment variables to be able to access the docker host.

These environment variables are DOCKER_MACHINE_NAME, DOCKER_CERT_PATH,
DOCKER_TLS_VERIFY & DOCKER_HOST.

Bazel does not pass environment variables to all actions by
default. You need to set use_default_shell_env. This patch enables
this option for docker actions so that a remote docker node can be
used (like is done with CircleCI).