### PR TITLE
Update ubuntu 16_0_4 and 18_0_4 to pick up security fixes

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -188,12 +188,12 @@ go_register_toolchains()
 
 UBUNTU_MAP = {
     "16_0_4": {
-        "sha256": "1e77bcd5bdfdd438110160b3dd7960ac4e98b5438658b5224c1dee22783a5f31",
-        "url": "https://storage.googleapis.com/ubuntu_tar/20190610/ubuntu-xenial-core-cloudimg-amd64-root.tar.gz",
+        "sha256": "e6943860ea52053a47ffe160596b24045a5cf6dcc37404dd258266e18fafd87e",
+        "url": "https://storage.googleapis.com/ubuntu_tar/20190627/ubuntu-xenial-core-cloudimg-amd64-root.tar.gz",
     },
     "18_0_4": {
-        "sha256": "3ade995de56cdf07c56fecd4c3b89e63dc851f8fcddfb163d459b43c5fbe911b",
-        "url": "https://storage.googleapis.com/ubuntu_tar/20190618/ubuntu-bionic-core-cloudimg-amd64-root.tar.gz",
+        "sha256": "63d6bf7644cb69313ad7f3371bccbe07932326ea29cf9cd369f29ad9da7b7b27",
+        "url": "https://storage.googleapis.com/ubuntu_tar/20190626/ubuntu-bionic-core-cloudimg-amd64-root.tar.gz",
     },
 }
 


### PR DESCRIPTION
Package differences:
1 for 18_0_4 image:
```
base-images-docker: (master)$ container-diff diff  daemon://bazel/ubuntu:ubuntu_18_0_4  remote://gcr.io/gcp-runtimes/ubuntu_18_0_4:latest
Starting diff on images daemon://bazel/ubuntu:ubuntu_18_0_4 and remote://gcr.io/gcp-runtimes/ubuntu_18_0_4:latest, using differs: [apt]
Computing diffs

-----Apt-----

Packages found only in bazel/ubuntu:ubuntu_18_0_4: None

Packages found only in gcr.io/gcp-runtimes/ubuntu_18_0_4:latest: None

Version differences:
PACKAGE             IMAGE1 (bazel/ubuntu:ubuntu_18_0_4)        IMAGE2 (gcr.io/gcp-runtimes/ubuntu_18_0_4:latest)
-bzip2              1.0.6-8.1ubuntu0.1, 177K                   1.0.6-8.1, 177K
-libbz2-1.0         1.0.6-8.1ubuntu0.1, 90K                    1.0.6-8.1, 90K
-libsystemd0        237-3ubuntu10.23, 648K                     237-3ubuntu10.22, 648K
-libudev1           237-3ubuntu10.23, 227K                     237-3ubuntu10.22, 227K
```

2. for 16_0_4 image:
```
container-diff diff  daemon://bazel/ubuntu:ubuntu_16_0_4  remote://gcr.io/gcp-runtimes/ubuntu_16_0_4:latest
Starting diff on images daemon://bazel/ubuntu:ubuntu_16_0_4 and remote://gcr.io/gcp-runtimes/ubuntu_16_0_4:latest, using differs: [apt]
Computing diffs

-----Apt-----

Packages found only in bazel/ubuntu:ubuntu_16_0_4: None

Packages found only in gcr.io/gcp-runtimes/ubuntu_16_0_4:latest: None

Version differences:
PACKAGE            IMAGE1 (bazel/ubuntu:ubuntu_16_0_4)        IMAGE2 (gcr.io/gcp-runtimes/ubuntu_16_0_4:latest)
-libbz2-1.0        1.0.6-8ubuntu0.1, 90K                      1.0.6-8, 109K

```