### PR TITLE
add flags for all the bazel commad in cloud build.

### DIFF
--- a/ubuntu1604/cloudbuild.yaml
+++ b/ubuntu1604/cloudbuild.yaml
@@ -41,7 +41,11 @@ steps:
 # We use container_test rule, which is a Bazel wrapper of container_structure_test.
 # https://github.com/bazelbuild/rules_docker/blob/master/contrib/test.bzl
   - name: "l.gcr.io/google/bazel"
-    args: ["--output_base=/workspace/ubuntu1604", "test", "--test_output=errors", "//:image-test"]
+    args: ["--output_base=/workspace/ubuntu1604", "test", "--test_output=errors", "//:image-test"
+           "--incompatible_disable_deprecated_attr_params=false",
+           "--incompatible_new_actions_api=false",
+           "--incompatible_no_support_tools_in_action_inputs=false",
+           "--host_force_python=PY2"]
     # This is needed for GCB to correctly build/test targets in the Bazel project.
     dir: "ubuntu1604"
     id: "structure-test"
@@ -50,14 +54,22 @@ steps:
 # Step: tag the image, first as the backup image.
   - name: "l.gcr.io/google/bazel"
     entrypoint: "docker"
-    args: ["tag", "bazel:image", "gcr.io/asci-toolchain-backup/ubuntu1604-xingao-test:latest"]
+    args: ["tag", "bazel:image", "gcr.io/asci-toolchain-backup/ubuntu1604-xingao-test:latest"
+           "--incompatible_disable_deprecated_attr_params=false",
+           "--incompatible_new_actions_api=false",
+           "--incompatible_no_support_tools_in_action_inputs=false",
+           "--host_force_python=PY2"]
     id: "backup-container-tag"
     waitFor: ["structure-test"]
 
 # Step: tag the image again with the final location.
   - name: "l.gcr.io/google/bazel"
     entrypoint: "docker"
-    args: ["tag", "bazel:image", "gcr.io/asci-toolchain/ubuntu1604-xingao-test:latest"]
+    args: ["tag", "bazel:image", "gcr.io/asci-toolchain/ubuntu1604-xingao-test:latest"
+           "--incompatible_disable_deprecated_attr_params=false",
+           "--incompatible_new_actions_api=false",
+           "--incompatible_no_support_tools_in_action_inputs=false",
+           "--host_force_python=PY2"]
     id: "container-tag"
     waitFor: ["backup-container-tag"]
 

--- a/ubuntu1804/cloudbuild.yaml
+++ b/ubuntu1804/cloudbuild.yaml
@@ -41,7 +41,11 @@ steps:
 # We use container_test rule, which is a Bazel wrapper of container_structure_test.
 # https://github.com/bazelbuild/rules_docker/blob/master/contrib/test.bzl
   - name: "l.gcr.io/google/bazel"
-    args: ["--output_base=/workspace/ubuntu1804", "test", "--test_output=errors", "//:image-test"]
+    args: ["--output_base=/workspace/ubuntu1804", "test", "--test_output=errors", "//:image-test"
+           "--incompatible_disable_deprecated_attr_params=false",
+           "--incompatible_new_actions_api=false",
+           "--incompatible_no_support_tools_in_action_inputs=false",
+           "--host_force_python=PY2"]
     # This is needed for GCB to correctly build/test targets in the Bazel project.
     dir: "ubuntu1804"
     id: "structure-test"
@@ -50,14 +54,22 @@ steps:
 # Step: tag the image, first as the backup image.
   - name: "l.gcr.io/google/bazel"
     entrypoint: "docker"
-    args: ["tag", "bazel:image", "gcr.io/asci-toolchain-backup/ubuntu1804-xingao-test:latest"]
+    args: ["tag", "bazel:image", "gcr.io/asci-toolchain-backup/ubuntu1804-xingao-test:latest"
+           "--incompatible_disable_deprecated_attr_params=false",
+           "--incompatible_new_actions_api=false",
+           "--incompatible_no_support_tools_in_action_inputs=false",
+           "--host_force_python=PY2"]
     id: "backup-container-tag"
     waitFor: ["structure-test"]
 
 # Step: tag the image again with the final location.
   - name: "l.gcr.io/google/bazel"
     entrypoint: "docker"
-    args: ["tag", "bazel:image", "gcr.io/asci-toolchain/ubuntu1804-xingao-test:latest"]
+    args: ["tag", "bazel:image", "gcr.io/asci-toolchain/ubuntu1804-xingao-test:latest"
+           "--incompatible_disable_deprecated_attr_params=false",
+           "--incompatible_new_actions_api=false",
+           "--incompatible_no_support_tools_in_action_inputs=false",
+           "--host_force_python=PY2"]
     id: "container-tag"
     waitFor: ["backup-container-tag"]
 


### PR DESCRIPTION
Signed-off-by: Tejal Desai <tejaldesai@google.com>

So, the this latest cloud build failed step 2
https://pantheon.corp.google.com/cloud-build/builds/4ff9d991-09e1-4555-81aa-b08e6f40f28a?project=gcp-runtimes&organizationId=433637338589 with 
```
FAILED: Build did NOT complete successfully
Executed 0 out of 1 test: 1 fails to build.

FAILED: Build did NOT complete successfully
INFO: 6 processes: 6 linux-sandbox.
INFO: Elapsed time: 15.715s, Critical Path: 4.90s
Use --verbose_failures to see the command lines of failed build steps.
Target //:image-test failed to build
[41 / 46] 1 / 1 tests, 1 failed; checking cached actions
----------------
If this error started occurring in Bazel 0.27 and later, it may be because the Python toolchain now enforces that targets analyzed as PY2 and PY3 run under a Python 2 and Python 3 interpreter, respectively. See https://github.com/bazelbuild/bazel/issues/7899 for more information.

Note: The failure of target @io_bazel_rules_docker//container:join_layers (with exit code 1) may have been caused by the fact that it is a Python 2 program that was built in the host configuration, which uses Python 3. You can change the host configuration (for the entire build) to instead use Python 2 by setting --host_force_python=PY2.
----------------
ImportError: No module named 'email.FeedParser'
    import email.FeedParser
  File "/workspace/ubuntu1604/sandbox/linux-sandbox/7/execroot/ubuntu1604/bazel-out/host/bin/external/io_bazel_rules_docker/container/join_layers.runfiles/httplib2/__init__.py", line 28, in <module>
    import httplib2
  File "/workspace/ubuntu1604/sandbox/linux-sandbox/7/execroot/ubuntu1604/bazel-out/host/bin/external/io_bazel_rules_docker/container/join_layers.runfiles/containerregistry/client/docker_creds_.py", line 31, in <module>
    from containerregistry.client import docker_creds_
  File "/workspace/ubuntu1604/sandbox/linux-sandbox/7/execroot/ubuntu1604/bazel-out/host/bin/external/io_bazel_rules_docker/container/join_layers.runfiles/containerregistry/client/__init__.py", line 23, in <module>
    from containerregistry.client import docker_name
  File "/workspace/ubuntu1604/sandbox/linux-sandbox/7/execroot/ubuntu1604/bazel-out/host/bin/external/io_bazel_rules_docker/container/join_layers.runfiles/io_bazel_rules_docker/container/join_layers.py", line 27, in <module>
Traceback (most recent call last):
Use --sandbox_debug to see verbose messages from the sandbox

ERROR: /workspace/ubuntu1604/BUILD:33:1: JoinLayers ubuntu1604_vanilla.tar failed (Exit 1) join_layers failed: error executing command bazel-out/host/bin/external/io_bazel_rules_docker/container/join_layers '--output=bazel-out/k8-fastbuild/bin/ubuntu1604_vanilla.tar' ... (remaining 3 argument(s) skipped)
[36 / 46] [Prepa] SHA256 ubuntu1604_vanilla-layer.tar.sha256
[35 / 46] ImageLayer ubuntu1604_vanilla-layer.tar; 0s linux-sandbox
[0 / 0] checking cached actions
INFO: Deleting stale sandbox base /workspace/ubuntu1604/sandbox
INFO: Found 1 test target...
INFO: Analyzed target //:image-test (41 packages loaded, 470 targets configured).
Analyzing: target //:image-test (40 packages loaded, 352 targets configured)
Analyzing: target //:image-test (40 packages loaded, 352 targets configured)
Analyzing: target //:image-test (39 packages loaded, 323 targets configured)
Analyzing: target //:image-test (37 packages loaded, 319 targets configured)
Analyzing: target //:image-test (1 packages loaded, 0 targets configured)
Loading: 0 packages loaded
Loading: 
Starting local Bazel server and connecting to it...
Already have image (with digest): l.gcr.io/google/bazel```