### PR TITLE
Enabling debian package metadata information for ubuntu 16.04

### DIFF
--- a/ubuntu1604/.bazelrc
+++ b/ubuntu1604/.bazelrc
@@ -1,0 +1,3 @@
+build --host_force_python=PY2
+test --host_force_python=PY2
+

--- a/ubuntu1604/BUILD
+++ b/ubuntu1604/BUILD
@@ -18,6 +18,7 @@ load(
     "@bazel_toolchains//rules/container:docker_toolchains.bzl",
     "toolchain_container",
 )
+load("@bazel_toolchains//rules/container:metadata_merge.bzl", "metadata_merge")
 load("@bazel_toolchains//rules/container:packages_metadata.bzl", "packages_metadata")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
@@ -48,13 +49,6 @@ download_pkgs(
     ],
 )
 
-# Transform the packages metadata csv produced by download_pkgs into a YAML
-# file.
-packages_metadata(
-    name = "metadata",
-    metadata_csv = ":debs_metadata.csv",
-)
-
 # Generate the container.
 toolchain_container(
     name = "image",
@@ -72,6 +66,23 @@ toolchain_container(
 security_check(
     name = "security_metadata",
     image = "gcr.io/asci-toolchain/ubuntu1604-xingao-test:latest",
+)
+
+# Transform the packages metadata csv produced by download_pkgs into a YAML
+# file.
+packages_metadata(
+    name = "debs_metadata",
+    metadata_csv = ":debs_metadata.csv",
+)
+
+# Merge the packages metadata & vulnerability YAML into a single merged YAML
+# file.
+metadata_merge(
+    name = "metadata",
+    srcs = [
+        ":debs_metadata.yaml",
+        ":security_metadata.yaml",
+    ],
 )
 
 container_test(

--- a/ubuntu1604/BUILD
+++ b/ubuntu1604/BUILD
@@ -18,6 +18,7 @@ load(
     "@bazel_toolchains//rules/container:docker_toolchains.bzl",
     "toolchain_container",
 )
+load("@bazel_toolchains//rules/container:packages_metadata.bzl", "packages_metadata")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
@@ -47,6 +48,13 @@ download_pkgs(
     ],
 )
 
+# Transform the packages metadata csv produced by download_pkgs into a YAML
+# file.
+packages_metadata(
+    name = "metadata",
+    metadata_csv = ":debs_metadata.csv",
+)
+
 # Generate the container.
 toolchain_container(
     name = "image",
@@ -64,7 +72,6 @@ toolchain_container(
 security_check(
     name = "security_metadata",
     image = "gcr.io/asci-toolchain/ubuntu1604-xingao-test:latest",
-    severity = "CRITICAL",
 )
 
 container_test(

--- a/ubuntu1604/WORKSPACE
+++ b/ubuntu1604/WORKSPACE
@@ -22,9 +22,9 @@ load(
 
 http_archive(
     name = "bazel_toolchains",
-    sha256 = "e886e0624871dcce823cccc7f9a634c58b0d68fdc3ad6577347826558f1581d8",
-    strip_prefix = "bazel-toolchains-9f6cd65b5fd8bc85634dafc99075556c06d8d3a6",
-    urls = ["https://github.com/bazelbuild/bazel-toolchains/archive/9f6cd65b5fd8bc85634dafc99075556c06d8d3a6.tar.gz"],
+    sha256 = "322ef052f15d61fdda3ff5c7be4b03d24e6543320b3b4b41da307aebd75b3c20",
+    strip_prefix = "bazel-toolchains-ae9c35af59cfe8af4a631550c0c8d37ff7f4e7da",
+    urls = ["https://github.com/bazelbuild/bazel-toolchains/archive/ae9c35af59cfe8af4a631550c0c8d37ff7f4e7da.tar.gz"],
 )
 
 http_archive(
@@ -34,12 +34,11 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_docker/archive/bb6d6606a6be348115af3552662799fd6d851a88.tar.gz"],
 )
 
-
 http_archive(
     name = "base_images_docker",
-    sha256 = "b4c2e1c181d1e6ebdee0d25420f2759c366ff2f77f2b60a7d919b7412c6c76f5",
-    strip_prefix = "base-images-docker-0bd1ce8c8e7b83da47f844359fa4aad6a5ab79d3",
-    urls = ["https://github.com/GoogleContainerTools/base-images-docker/archive/0bd1ce8c8e7b83da47f844359fa4aad6a5ab79d3.tar.gz"],
+    sha256 = "0319ed0e058ec57cb15240cad44b52743b68239e5875fa41db51a6f6ac8e67be",
+    strip_prefix = "base-images-docker-d6f2757c3c48bd6c08e6484d02b84ed123d50ffa",
+    urls = ["https://github.com/GoogleContainerTools/base-images-docker/archive/d6f2757c3c48bd6c08e6484d02b84ed123d50ffa.tar.gz"],
 )
 
 load("@base_images_docker//package_managers:repositories.bzl", package_manager_deps = "deps")
@@ -83,6 +82,13 @@ load(
     "@io_bazel_rules_docker//repositories:repositories.bzl",
     container_repositories = "repositories",
 )
+load("@bazel_toolchains//repositories:repositories.bzl", bazel_toolchains_repos = "repositories")
+
+bazel_toolchains_repos()
+
+load("@bazel_toolchains//repositories:go_repositories.bzl", bazel_toolchains_go_repos = "go_deps")
+
+bazel_toolchains_go_repos()
 
 container_repositories()
 

--- a/ubuntu1604/deps_spec.yaml
+++ b/ubuntu1604/deps_spec.yaml
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 revisionsFilePath: "ubuntu1604/revisions.bzl"
+metadataSummaryFilePath: "ubuntu1604/metadata_summary.yaml"
 
 gcsDeps:
 
@@ -22,6 +23,8 @@ gcsDeps:
     versionRegex: "\\d{8,}"
     fileRegex: "^ubuntu1604/tar/\\d{8,}_ubuntu1604\\.tar\\.gz$"
     startsWith: "ubuntu1604/tar/"
+    fusMetadataBucket: "container-deps"
+    fusMetadataObject: "ubuntu1604/metadata/debs/metadata.yaml"
 
   # The Debian packages tarball pulled from the GCS bucket required for the Ubuntu1604 container.
   - name: "DEBS_TARBALL"

--- a/ubuntu1604/deps_spec.yaml
+++ b/ubuntu1604/deps_spec.yaml
@@ -28,6 +28,8 @@ gcsDeps:
     releasePolicies:
       - tag: "default"
         # Weekly release schedule at 5am every Monday.
+        # TODO (smukherj1): Change schedule to monthly once the automatic
+        # updates infrastructure is deemed to be stable.
         schedule: "0 0 5 * * Mon"
         # Release immediate for security vulnerabilities with severity medium
         # or higher.

--- a/ubuntu1604/deps_spec.yaml
+++ b/ubuntu1604/deps_spec.yaml
@@ -25,6 +25,18 @@ gcsDeps:
     startsWith: "ubuntu1604/tar/"
     fusMetadataBucket: "container-deps"
     fusMetadataObject: "ubuntu1604/metadata/debs/metadata.yaml"
+    releasePolicies:
+      - tag: "default"
+        # Weekly release schedule at 5am every Monday.
+        schedule: "0 0 5 * * Mon"
+        # Release immediate for security vulnerabilities with severity medium
+        # or higher.
+      - tag: "cveMedium"
+        schedule: "* * * * * *"
+      - tag: "cveHigh"
+        schedule: "* * * * * *"
+      - tag: "cveCritical"
+        schedule: "* * * * * *"
 
   # The Debian packages tarball pulled from the GCS bucket required for the Ubuntu1604 container.
   - name: "DEBS_TARBALL"

--- a/ubuntu1604/file_updates.yaml
+++ b/ubuntu1604/file_updates.yaml
@@ -26,6 +26,10 @@
     target: "//:debs.tar"
     bucket: "container-deps"
     dir: "ubuntu1604/debs"
+    metadata:
+        target: "//:metadata.yaml"
+        bucket: "container-deps"
+        object: "ubuntu1604/metadata/debs/metadata.yaml"
 
 # Ubuntu1604 base image tarball.
 - triggerFile:


### PR DESCRIPTION
Enabling metadata about debian packages included in the debian package
tarball tracked by file update service and generate a file with a
summary of the changes introduced by a pull request generated by
dependency update service.