### PR TITLE
Run security check for ubuntu base image updates as well

### DIFF
--- a/ubuntu1604/deps_spec.yaml
+++ b/ubuntu1604/deps_spec.yaml
@@ -24,7 +24,7 @@ gcsDeps:
     fileRegex: "^ubuntu1604/tar/\\d{8,}_ubuntu1604\\.tar\\.gz$"
     startsWith: "ubuntu1604/tar/"
     fusMetadataBucket: "container-deps"
-    fusMetadataObject: "ubuntu1604/metadata/debs/metadata.yaml"
+    fusMetadataObject: "ubuntu1604/metadata/tar/metadata.yaml"
     releasePolicies:
       - tag: "default"
         # Weekly release schedule at 5am every Monday.
@@ -46,3 +46,19 @@ gcsDeps:
     versionRegex: "\\d{8,}"
     fileRegex: "^ubuntu1604/debs/\\d{8,}_debs\\.tar$"
     startsWith: "ubuntu1604/debs/"
+    fusMetadataBucket: "container-deps"
+    fusMetadataObject: "ubuntu1604/metadata/debs/metadata.yaml"
+    releasePolicies:
+      - tag: "default"
+        # Weekly release schedule at 5am every Monday.
+        # TODO (smukherj1): Change schedule to monthly once the automatic
+        # updates infrastructure is deemed to be stable.
+        schedule: "0 0 5 * * Mon"
+        # Release immediate for security vulnerabilities with severity medium
+        # or higher.
+      - tag: "cveMedium"
+        schedule: "* * * * * *"
+      - tag: "cveHigh"
+        schedule: "* * * * * *"
+      - tag: "cveCritical"
+        schedule: "* * * * * *"

--- a/ubuntu1604/file_updates.yaml
+++ b/ubuntu1604/file_updates.yaml
@@ -36,3 +36,7 @@
     target: "@ubuntu1604_tar_latest//file:ubuntu1604.tar.gz"
     bucket: "container-deps"
     dir: "ubuntu1604/tar"
+    metadata:
+        target: "//:metadata.yaml"
+        bucket: "container-deps"
+        object: "ubuntu1604/metadata/tar/metadata.yaml"


### PR DESCRIPTION
This should trigger an update regardless of whether the debian packages
had an update or the base image. Previously, an update would be
triggered by a debian package update only.