### PR TITLE
remove dependency on bazel-toolchains repo

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,8 +20,7 @@ the host machine.
 
 workspace(name = "base_images_docker")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
@@ -33,9 +32,9 @@ git_repository(
 # Docker rules.
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "b16afde01b99f8b9a067b98903a5fa1879307f9344ccdbbc4aa796ae657e910f",
-    strip_prefix = "rules_docker-4ea9e6708ec5ac29dc18f991921e2c064969159a",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/4ea9e6708ec5ac29dc18f991921e2c064969159a.tar.gz"],
+    sha256 = "9ff889216e28c918811b77999257d4ac001c26c1f7c7fb17a79bc28abf74182e",
+    strip_prefix = "rules_docker-0.10.1",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.10.1/rules_docker-v0.10.1.tar.gz"],
 )
 
 load(
@@ -189,7 +188,7 @@ UBUNTU_MAP = {
     "18_0_4": {
         "sha256": "600f663706aa8e7cb30d114daee117536545b5a580bca6a97b3cb73d72acdcee",
         "url": "https://storage.googleapis.com/ubuntu_tar/20190704/ubuntu-bionic-core-cloudimg-amd64-root.tar.gz",
-    }
+    },
 }
 
 [http_file(

--- a/centos7/WORKSPACE
+++ b/centos7/WORKSPACE
@@ -18,9 +18,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "01f1826346a828410666d69df1a748f3a5a3b33924b9369c25064a7a553b133a",
-    strip_prefix = "rules_docker-f829974af764c60d57ef6630ea4b8499529d0093",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/f829974af764c60d57ef6630ea4b8499529d0093.tar.gz"],
+    sha256 = "9ff889216e28c918811b77999257d4ac001c26c1f7c7fb17a79bc28abf74182e",
+    strip_prefix = "rules_docker-0.10.1",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.10.1/rules_docker-v0.10.1.tar.gz"],
 )
 
 http_archive(

--- a/debian9/BUILD
+++ b/debian9/BUILD
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load(
-    "@bazel_toolchains//rules/container:docker_toolchains.bzl",
-    "toolchain_container",
-)
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:repro_test.bzl", "container_repro_test")
@@ -26,6 +22,10 @@ load(
 )
 load("@io_bazel_rules_docker//docker/security:security_check.bzl", "security_check")
 load("@io_bazel_rules_docker//docker/util:run.bzl", "container_run_and_extract")
+load(
+    "@io_bazel_rules_docker//docker/toolchain_container:toolchain_container.bzl",
+    "toolchain_container",
+)
 
 licenses(["notice"])  # Apache 2.0
 

--- a/debian9/WORKSPACE
+++ b/debian9/WORKSPACE
@@ -17,17 +17,10 @@ workspace(name = "debian9")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "bazel_toolchains",
-    sha256 = "7d0c157364ce8dac5282af7c7b9e8d9e2c4ee7a6a30dfdb763e9e40b09a656e9",
-    strip_prefix = "bazel-toolchains-e6e7db64dfcfe82f54782a75ee549b0e392ecefc",
-    urls = ["https://github.com/bazelbuild/bazel-toolchains/archive/e6e7db64dfcfe82f54782a75ee549b0e392ecefc.tar.gz"],
-)
-
-http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "01f1826346a828410666d69df1a748f3a5a3b33924b9369c25064a7a553b133a",
-    strip_prefix = "rules_docker-f829974af764c60d57ef6630ea4b8499529d0093",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/f829974af764c60d57ef6630ea4b8499529d0093.tar.gz"],
+    sha256 = "9ff889216e28c918811b77999257d4ac001c26c1f7c7fb17a79bc28abf74182e",
+    strip_prefix = "rules_docker-0.10.1",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.10.1/rules_docker-v0.10.1.tar.gz"],
 )
 
 http_archive(

--- a/tests/package_managers/BUILD
+++ b/tests/package_managers/BUILD
@@ -18,7 +18,6 @@ load(
     "@bazel_tools//tools/build_rules:test_rules.bzl",
     "rule_test",
 )
-load("@io_bazel_rules_docker//contrib:compare_ids_test.bzl", "compare_ids_test")
 load("//package_managers:bootstrap_image.bzl", "bootstrap_image_macro")
 
 bootstrap_image_macro(

--- a/ubuntu1604/BUILD
+++ b/ubuntu1604/BUILD
@@ -12,12 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load(
-    "@bazel_toolchains//rules/container:docker_toolchains.bzl",
-    "toolchain_container",
-)
-load("@bazel_toolchains//rules/container:metadata_merge.bzl", "metadata_merge")
-load("@bazel_toolchains//rules/container:packages_metadata.bzl", "packages_metadata")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:repro_test.bzl", "container_repro_test")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
@@ -25,8 +19,14 @@ load(
     "@io_bazel_rules_docker//contrib/automatic_container_release:configs_test.bzl",
     "configs_test",
 )
+load("@io_bazel_rules_docker//contrib/automatic_container_release:metadata_merge.bzl", "metadata_merge")
+load("@io_bazel_rules_docker//contrib/automatic_container_release:packages_metadata.bzl", "packages_metadata")
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/security:security_check.bzl", "security_check")
+load(
+    "@io_bazel_rules_docker//docker/toolchain_container:toolchain_container.bzl",
+    "toolchain_container",
+)
 
 licenses(["notice"])  # Apache 2.0
 

--- a/ubuntu1604/WORKSPACE
+++ b/ubuntu1604/WORKSPACE
@@ -21,17 +21,10 @@ load(
 )
 
 http_archive(
-    name = "bazel_toolchains",
-    sha256 = "7d0c157364ce8dac5282af7c7b9e8d9e2c4ee7a6a30dfdb763e9e40b09a656e9",
-    strip_prefix = "bazel-toolchains-e6e7db64dfcfe82f54782a75ee549b0e392ecefc",
-    urls = ["https://github.com/bazelbuild/bazel-toolchains/archive/e6e7db64dfcfe82f54782a75ee549b0e392ecefc.tar.gz"],
-)
-
-http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "01f1826346a828410666d69df1a748f3a5a3b33924b9369c25064a7a553b133a",
-    strip_prefix = "rules_docker-f829974af764c60d57ef6630ea4b8499529d0093",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/f829974af764c60d57ef6630ea4b8499529d0093.tar.gz"],
+    sha256 = "9ff889216e28c918811b77999257d4ac001c26c1f7c7fb17a79bc28abf74182e",
+    strip_prefix = "rules_docker-0.10.1",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.10.1/rules_docker-v0.10.1.tar.gz"],
 )
 
 http_archive(
@@ -58,13 +51,6 @@ load(
     "@io_bazel_rules_docker//repositories:repositories.bzl",
     container_repositories = "repositories",
 )
-load("@bazel_toolchains//repositories:repositories.bzl", bazel_toolchains_repos = "repositories")
-
-bazel_toolchains_repos()
-
-load("@bazel_toolchains//repositories:go_repositories.bzl", bazel_toolchains_go_repos = "go_deps")
-
-bazel_toolchains_go_repos()
 
 container_repositories()
 

--- a/ubuntu1804/BUILD
+++ b/ubuntu1804/BUILD
@@ -12,12 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load(
-    "@bazel_toolchains//rules/container:docker_toolchains.bzl",
-    "toolchain_container",
-)
-load("@bazel_toolchains//rules/container:metadata_merge.bzl", "metadata_merge")
-load("@bazel_toolchains//rules/container:packages_metadata.bzl", "packages_metadata")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:repro_test.bzl", "container_repro_test")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
@@ -25,8 +19,14 @@ load(
     "@io_bazel_rules_docker//contrib/automatic_container_release:configs_test.bzl",
     "configs_test",
 )
+load("@io_bazel_rules_docker//contrib/automatic_container_release:metadata_merge.bzl", "metadata_merge")
+load("@io_bazel_rules_docker//contrib/automatic_container_release:packages_metadata.bzl", "packages_metadata")
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/security:security_check.bzl", "security_check")
+load(
+    "@io_bazel_rules_docker//docker/toolchain_container:toolchain_container.bzl",
+    "toolchain_container",
+)
 
 licenses(["notice"])  # Apache 2.0
 

--- a/ubuntu1804/WORKSPACE
+++ b/ubuntu1804/WORKSPACE
@@ -21,17 +21,10 @@ load(
 )
 
 http_archive(
-    name = "bazel_toolchains",
-    sha256 = "7d0c157364ce8dac5282af7c7b9e8d9e2c4ee7a6a30dfdb763e9e40b09a656e9",
-    strip_prefix = "bazel-toolchains-e6e7db64dfcfe82f54782a75ee549b0e392ecefc",
-    urls = ["https://github.com/bazelbuild/bazel-toolchains/archive/e6e7db64dfcfe82f54782a75ee549b0e392ecefc.tar.gz"],
-)
-
-http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "01f1826346a828410666d69df1a748f3a5a3b33924b9369c25064a7a553b133a",
-    strip_prefix = "rules_docker-f829974af764c60d57ef6630ea4b8499529d0093",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/f829974af764c60d57ef6630ea4b8499529d0093.tar.gz"],
+    sha256 = "9ff889216e28c918811b77999257d4ac001c26c1f7c7fb17a79bc28abf74182e",
+    strip_prefix = "rules_docker-0.10.1",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.10.1/rules_docker-v0.10.1.tar.gz"],
 )
 
 http_archive(
@@ -60,14 +53,6 @@ load(
 )
 
 container_repositories()
-
-load("@bazel_toolchains//repositories:repositories.bzl", bazel_toolchains_repos = "repositories")
-
-bazel_toolchains_repos()
-
-load("@bazel_toolchains//repositories:go_repositories.bzl", bazel_toolchains_go_repos = "go_deps")
-
-bazel_toolchains_go_repos()
 
 load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
 


### PR DESCRIPTION
All rules needed for container building / releasing have been moved to rules_docker. Single dep should be easier to handle. We will be setting up later this week the DUS service to automatically update the rules_docker pin after every release.