### PR TITLE
Point debian_base to valid image

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -87,13 +87,6 @@ container_pull(
     repository = "google-appengine/debian9",
 )
 
-container_pull(
-    name = "debian_base",
-    digest = "sha256:00109fa40230a081f5ecffe0e814725042ff62a03e2d1eae0563f1f82eaeae9b",
-    registry = "gcr.io",
-    repository = "google-appengine/debian10",
-)
-
 git_repository(
     name = "distroless",
     commit = "a4fd5de337e31911aeee2ad5248284cebeb6a6f4",

--- a/debian10/WORKSPACE
+++ b/debian10/WORKSPACE
@@ -53,11 +53,17 @@ load(
 )
 
 # Pull existing Debian base, only used to create builder image to debootstrap.
+#container_pull(
+#    name = "debian_base",
+#    digest = "sha256:00109fa40230a081f5ecffe0e814725042ff62a03e2d1eae0563f1f82eaeae9b",
+#    registry = "gcr.io",
+#    repository = "google-appengine/debian10",
+#)
 container_pull(
     name = "debian_base",
-    digest = "sha256:00109fa40230a081f5ecffe0e814725042ff62a03e2d1eae0563f1f82eaeae9b",
-    registry = "gcr.io",
-    repository = "google-appengine/debian10",
+    registry = "index.docker.io",
+    repository = "library/debian",
+    tag = "10",
 )
 
 load(":deps.bzl", "deps")


### PR DESCRIPTION
Okay, first we have to point debian_base to a valid debian image, and then the FUS service will generate another one from scratch and populate google-appengine gcr.