### PR TITLE
centos7: restore rpm packages to allow CVE scans

### DIFF
--- a/centos7/build.sh
+++ b/centos7/build.sh
@@ -25,7 +25,6 @@ rm -rf /var/lib/yum/uuid
 echo 'container' > /etc/yum/vars/infra
 rm -rf /var/cache/yum/x86_64
 rm -f /var/log/yum.log
-rm -rf /var/lib/rpm/*
 rm -rf /var/lib/systemd/random-seed
 rm -rf /etc/pki/ca-trust/extracted/java
 #rpm --rebuilddb


### PR DESCRIPTION
To fix https://github.com/GoogleContainerTools/base-images-docker/issues/913 

Restore `/var/lib/rpm/Packages` so that CVE scanners can read OS packages on CentOS7 image.