### PR TITLE
Update rules_docker version

### DIFF
--- a/centos7/WORKSPACE
+++ b/centos7/WORKSPACE
@@ -24,14 +24,6 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_docker/archive/" + RULES_DOCKER.commit + ".tar.gz"],
 )
 
-http_archive(
-    name = "bazel_skylib",
-    # Commit c00ef493869e2966d47508e8625aae723a4a3054 of 2018-12-10
-    sha256 = "7363ae6721c1648017e23a200013510c9e71ca69f398d52886ee6af7f26af436",
-    strip_prefix = "bazel-skylib-c00ef493869e2966d47508e8625aae723a4a3054",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/archive/c00ef493869e2966d47508e8625aae723a4a3054.tar.gz"],
-)
-
 load(
     "@io_bazel_rules_docker//repositories:repositories.bzl",
     container_repositories = "repositories",

--- a/centos7/revisions.bzl
+++ b/centos7/revisions.bzl
@@ -21,6 +21,6 @@ CENTOS7_TAR = struct(
 )
 
 RULES_DOCKER = struct(
-    commit = "f1557ebc5381e2a662314e21585aa8080e9508be",
-    sha256 = "ffd6ee22fceb7db4d6e6f75bf69ecf439da7500ec2969fc5d371d165ceb22e3f",
+    commit = "faaa10a72fa9abde070e2a20d6046e9f9b849e9a",
+    sha256 = "feb53c560be2f97b7d02b23a1738a3154ba89fe630f09a7a838dcad38731b0b8",
 )

--- a/debian10/WORKSPACE
+++ b/debian10/WORKSPACE
@@ -24,14 +24,6 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_docker/archive/" + RULES_DOCKER.commit + ".tar.gz"],
 )
 
-http_archive(
-    name = "bazel_skylib",
-    # Commit c00ef493869e2966d47508e8625aae723a4a3054 of 2018-12-10
-    sha256 = "7363ae6721c1648017e23a200013510c9e71ca69f398d52886ee6af7f26af436",
-    strip_prefix = "bazel-skylib-c00ef493869e2966d47508e8625aae723a4a3054",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/archive/c00ef493869e2966d47508e8625aae723a4a3054.tar.gz"],
-)
-
 load(
     "@io_bazel_rules_docker//repositories:repositories.bzl",
     container_repositories = "repositories",

--- a/debian10/revisions.bzl
+++ b/debian10/revisions.bzl
@@ -21,6 +21,6 @@ DEBIAN10_TAR = struct(
 )
 
 RULES_DOCKER = struct(
-    commit = "f1557ebc5381e2a662314e21585aa8080e9508be",
-    sha256 = "ffd6ee22fceb7db4d6e6f75bf69ecf439da7500ec2969fc5d371d165ceb22e3f",
+    commit = "faaa10a72fa9abde070e2a20d6046e9f9b849e9a",
+    sha256 = "feb53c560be2f97b7d02b23a1738a3154ba89fe630f09a7a838dcad38731b0b8",
 )

--- a/debian9/WORKSPACE
+++ b/debian9/WORKSPACE
@@ -24,14 +24,6 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_docker/archive/" + RULES_DOCKER.commit + ".tar.gz"],
 )
 
-http_archive(
-    name = "bazel_skylib",
-    # Commit c00ef493869e2966d47508e8625aae723a4a3054 of 2018-12-10
-    sha256 = "7363ae6721c1648017e23a200013510c9e71ca69f398d52886ee6af7f26af436",
-    strip_prefix = "bazel-skylib-c00ef493869e2966d47508e8625aae723a4a3054",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/archive/c00ef493869e2966d47508e8625aae723a4a3054.tar.gz"],
-)
-
 load(
     "@io_bazel_rules_docker//repositories:repositories.bzl",
     container_repositories = "repositories",

--- a/debian9/revisions.bzl
+++ b/debian9/revisions.bzl
@@ -21,6 +21,6 @@ DEBIAN9_TAR = struct(
 )
 
 RULES_DOCKER = struct(
-    commit = "f1557ebc5381e2a662314e21585aa8080e9508be",
-    sha256 = "ffd6ee22fceb7db4d6e6f75bf69ecf439da7500ec2969fc5d371d165ceb22e3f",
+    commit = "faaa10a72fa9abde070e2a20d6046e9f9b849e9a",
+    sha256 = "feb53c560be2f97b7d02b23a1738a3154ba89fe630f09a7a838dcad38731b0b8",
 )

--- a/ubuntu1604/WORKSPACE
+++ b/ubuntu1604/WORKSPACE
@@ -28,14 +28,6 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_docker/archive/" + RULES_DOCKER.commit + ".tar.gz"],
 )
 
-http_archive(
-    name = "bazel_skylib",
-    # Commit c00ef493869e2966d47508e8625aae723a4a3054 of 2018-12-10
-    sha256 = "7363ae6721c1648017e23a200013510c9e71ca69f398d52886ee6af7f26af436",
-    strip_prefix = "bazel-skylib-c00ef493869e2966d47508e8625aae723a4a3054",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/archive/c00ef493869e2966d47508e8625aae723a4a3054.tar.gz"],
-)
-
 # Non-deterministic latest version of ubuntu1604 base tarball. This is used by
 # File Update Service to archive each version in our managed GCS bucket, and
 # should NOT be used by container release directly.

--- a/ubuntu1604/revisions.bzl
+++ b/ubuntu1604/revisions.bzl
@@ -26,6 +26,6 @@ DEBS_TARBALL = struct(
 )
 
 RULES_DOCKER = struct(
-    commit = "f1557ebc5381e2a662314e21585aa8080e9508be",
-    sha256 = "ffd6ee22fceb7db4d6e6f75bf69ecf439da7500ec2969fc5d371d165ceb22e3f",
+    commit = "faaa10a72fa9abde070e2a20d6046e9f9b849e9a",
+    sha256 = "feb53c560be2f97b7d02b23a1738a3154ba89fe630f09a7a838dcad38731b0b8",
 )

--- a/ubuntu1804/WORKSPACE
+++ b/ubuntu1804/WORKSPACE
@@ -28,14 +28,6 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_docker/archive/" + RULES_DOCKER.commit + ".tar.gz"],
 )
 
-http_archive(
-    name = "bazel_skylib",
-    # Commit c00ef493869e2966d47508e8625aae723a4a3054 of 2018-12-10
-    sha256 = "7363ae6721c1648017e23a200013510c9e71ca69f398d52886ee6af7f26af436",
-    strip_prefix = "bazel-skylib-c00ef493869e2966d47508e8625aae723a4a3054",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/archive/c00ef493869e2966d47508e8625aae723a4a3054.tar.gz"],
-)
-
 # Non-deterministic latest version of ubuntu1604 base tarball. This is used by
 # File Update Service to archive each version in our managed GCS bucket, and
 # should NOT be used by container release directly.

--- a/ubuntu1804/revisions.bzl
+++ b/ubuntu1804/revisions.bzl
@@ -26,6 +26,6 @@ DEBS_TARBALL = struct(
 )
 
 RULES_DOCKER = struct(
-    commit = "f1557ebc5381e2a662314e21585aa8080e9508be",
-    sha256 = "ffd6ee22fceb7db4d6e6f75bf69ecf439da7500ec2969fc5d371d165ceb22e3f",
+    commit = "faaa10a72fa9abde070e2a20d6046e9f9b849e9a",
+    sha256 = "feb53c560be2f97b7d02b23a1738a3154ba89fe630f09a7a838dcad38731b0b8",
 )


### PR DESCRIPTION
This fixes building FUS targets with the latest Bazel 3.4.1.
`gflags` was removed from `bazel_tools` which is now reflected in the latest release of `rules_docker`.