### PR TITLE
Leave extracted java ca-certs in place

### DIFF
--- a/centos7/build.sh
+++ b/centos7/build.sh
@@ -20,7 +20,6 @@ chroot /target ./chroot.sh ${1}
 yum clean all
 echo 'container' > /etc/yum/vars/infra
 rm -rf /var/lib/systemd/random-seed
-rm -rf /etc/pki/ca-trust/extracted/java
 #rpm --rebuilddb
 
 umount /target/dev/


### PR DESCRIPTION
Removing the extracted java ca-certs was one of the ways we ensured the image would remain stable on rebuild, but it causes larger problems for users.